### PR TITLE
Add Lie Group Utilities

### DIFF
--- a/src/main/java/us/ihmc/euclid/lieGroup/SE3LieGroupTools.java
+++ b/src/main/java/us/ihmc/euclid/lieGroup/SE3LieGroupTools.java
@@ -1,0 +1,271 @@
+package us.ihmc.euclid.lieGroup;
+
+import org.ejml.data.DMatrixRMaj;
+
+import us.ihmc.euclid.matrix.Matrix3D;
+import us.ihmc.euclid.matrix.RotationMatrix;
+import us.ihmc.euclid.transform.interfaces.RigidBodyTransformBasics;
+import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
+import us.ihmc.euclid.tuple3D.Vector3D;
+
+/**
+ * Static utility class providing SE(3) Lie group and Lie algebra operations.
+ *
+ * <p>The Lie algebra se(3) is identified with ℝ⁶ via the hat/vee isomorphism.
+ * The 6-vector convention is {@code ξ = [ρ; φ]} where:
+ * <ul>
+ *   <li>ρ = xi[0..2] — translational (linear) component</li>
+ *   <li>φ = xi[3..5] — rotational (angular) component</li>
+ * </ul>
+ * </p>
+ *
+ * <p>The hat map produces a 4×4 matrix:
+ * <pre>
+ *            [ hat(φ)   ρ ]
+ *   hat(ξ) = [            ]
+ *            [  0  0  0 0 ]
+ * </pre>
+ * </p>
+ *
+ * <p>The SE(3) group adjoint (6×6) for T = (R, t) with 6-vector ordering [ρ; φ] is:
+ * <pre>
+ *   Ad_T = [ R    hat(t)·R ]
+ *          [ 0       R     ]
+ * </pre>
+ * </p>
+ *
+ * <p>Allocation note: {@link #exp}, {@link #log}, {@link #adjoint}, and
+ * {@link #smallAdjoint} allocate small temporaries. They are <em>not</em> suitable
+ * for hard real-time loops without pre-allocation wrappers.</p>
+ */
+public class SE3LieGroupTools
+{
+   private SE3LieGroupTools()
+   {
+   }
+
+   // -----------------------------------------------------------------------
+   // hat / vee
+   // -----------------------------------------------------------------------
+
+   /**
+    * SE(3) hat map: converts a 6-vector ξ = [ρ; φ] to a 4×4 se(3) matrix.
+    *
+    * <pre>
+    * xi[0..2] = ρ (translation part),  xi[3..5] = φ (rotation part)
+    *
+    *            [  0   -φz   φy   ρx ]
+    *            [ φz    0   -φx   ρy ]
+    * hat(ξ) =   [-φy   φx    0    ρz ]
+    *            [  0    0    0     0  ]
+    * </pre>
+    *
+    * @param xi          6-element array [ρx, ρy, ρz, φx, φy, φz]. Not modified.
+    * @param matrixToPack 4×4 matrix to pack the result into (must be at least 4×4). Modified.
+    */
+   public static void hat(double[] xi, DMatrixRMaj matrixToPack)
+   {
+      double rhoX = xi[0], rhoY = xi[1], rhoZ = xi[2];
+      double phiX = xi[3], phiY = xi[4], phiZ = xi[5];
+
+      matrixToPack.unsafe_set(0, 0, 0.0);
+      matrixToPack.unsafe_set(0, 1, -phiZ);
+      matrixToPack.unsafe_set(0, 2, phiY);
+      matrixToPack.unsafe_set(0, 3, rhoX);
+
+      matrixToPack.unsafe_set(1, 0, phiZ);
+      matrixToPack.unsafe_set(1, 1, 0.0);
+      matrixToPack.unsafe_set(1, 2, -phiX);
+      matrixToPack.unsafe_set(1, 3, rhoY);
+
+      matrixToPack.unsafe_set(2, 0, -phiY);
+      matrixToPack.unsafe_set(2, 1, phiX);
+      matrixToPack.unsafe_set(2, 2, 0.0);
+      matrixToPack.unsafe_set(2, 3, rhoZ);
+
+      matrixToPack.unsafe_set(3, 0, 0.0);
+      matrixToPack.unsafe_set(3, 1, 0.0);
+      matrixToPack.unsafe_set(3, 2, 0.0);
+      matrixToPack.unsafe_set(3, 3, 0.0);
+   }
+
+   /**
+    * SE(3) vee map: extracts the 6-vector ξ = [ρ; φ] from a 4×4 se(3) hat matrix.
+    *
+    * @param hatMatrix  4×4 se(3) hat matrix. Not modified.
+    * @param xiToPack   6-element array to pack [ρx, ρy, ρz, φx, φy, φz] into. Modified.
+    */
+   public static void vee(DMatrixRMaj hatMatrix, double[] xiToPack)
+   {
+      xiToPack[0] = hatMatrix.unsafe_get(0, 3); // ρx
+      xiToPack[1] = hatMatrix.unsafe_get(1, 3); // ρy
+      xiToPack[2] = hatMatrix.unsafe_get(2, 3); // ρz
+      xiToPack[3] = hatMatrix.unsafe_get(2, 1); // φx
+      xiToPack[4] = hatMatrix.unsafe_get(0, 2); // φy
+      xiToPack[5] = hatMatrix.unsafe_get(1, 0); // φz
+   }
+
+   // -----------------------------------------------------------------------
+   // exp / log
+   // -----------------------------------------------------------------------
+
+   /**
+    * SE(3) exponential map: converts a Lie algebra element ξ = [ρ; φ] to a rigid-body transform.
+    *
+    * <p>Formula: R = exp(hat(φ)), t = J_l(φ) · ρ.</p>
+    *
+    * @param xi          6-element array [ρx, ρy, ρz, φx, φy, φz]. Not modified.
+    * @param transformToPack the rigid-body transform to pack the result into. Modified.
+    */
+   public static void exp(double[] xi, RigidBodyTransformBasics transformToPack)
+   {
+      Vector3D phi = new Vector3D(xi[3], xi[4], xi[5]);
+
+      RotationMatrix R = new RotationMatrix();
+      SO3LieGroupTools.exp(phi, R);
+
+      Matrix3D Jl = new Matrix3D();
+      SO3LieGroupTools.leftJacobian(phi, Jl);
+
+      double rhoX = xi[0], rhoY = xi[1], rhoZ = xi[2];
+      double tx = Jl.getM00() * rhoX + Jl.getM01() * rhoY + Jl.getM02() * rhoZ;
+      double ty = Jl.getM10() * rhoX + Jl.getM11() * rhoY + Jl.getM12() * rhoZ;
+      double tz = Jl.getM20() * rhoX + Jl.getM21() * rhoY + Jl.getM22() * rhoZ;
+
+      transformToPack.getRotation().set(R);
+      transformToPack.getTranslation().set(tx, ty, tz);
+   }
+
+   /**
+    * SE(3) logarithmic map: converts a rigid-body transform to its Lie algebra element ξ = [ρ; φ].
+    *
+    * <p>Formula: φ = log(R), ρ = J_l⁻¹(φ) · t.</p>
+    *
+    * @param transform  the rigid-body transform. Not modified.
+    * @param xiToPack   6-element array to pack [ρx, ρy, ρz, φx, φy, φz] into. Modified.
+    */
+   public static void log(RigidBodyTransformReadOnly transform, double[] xiToPack)
+   {
+      Vector3D phi = new Vector3D();
+      SO3LieGroupTools.log(transform.getRotation(), phi);
+
+      Matrix3D JlInv = new Matrix3D();
+      SO3LieGroupTools.leftJacobianInverse(phi, JlInv);
+
+      double tx = transform.getTranslation().getX();
+      double ty = transform.getTranslation().getY();
+      double tz = transform.getTranslation().getZ();
+
+      xiToPack[0] = JlInv.getM00() * tx + JlInv.getM01() * ty + JlInv.getM02() * tz;
+      xiToPack[1] = JlInv.getM10() * tx + JlInv.getM11() * ty + JlInv.getM12() * tz;
+      xiToPack[2] = JlInv.getM20() * tx + JlInv.getM21() * ty + JlInv.getM22() * tz;
+      xiToPack[3] = phi.getX();
+      xiToPack[4] = phi.getY();
+      xiToPack[5] = phi.getZ();
+   }
+
+   // -----------------------------------------------------------------------
+   // Adjoint representations
+   // -----------------------------------------------------------------------
+
+   /**
+    * Group adjoint Ad_T (6×6) for T = (R, t), with 6-vector ordering [ρ; φ].
+    *
+    * <pre>
+    *   Ad_T = [ R    hat(t)·R ]
+    *          [ 0       R     ]
+    * </pre>
+    *
+    * @param transform    the SE(3) element T. Not modified.
+    * @param adjToPack    6×6 DMatrixRMaj to pack Ad_T into (must be at least 6×6). Modified.
+    */
+   public static void adjoint(RigidBodyTransformReadOnly transform, DMatrixRMaj adjToPack)
+   {
+      RotationMatrix R = new RotationMatrix();
+      R.set(transform.getRotation());
+
+      double tx = transform.getTranslation().getX();
+      double ty = transform.getTranslation().getY();
+      double tz = transform.getTranslation().getZ();
+
+      // hat(t) = [[0, -tz, ty], [tz, 0, -tx], [-ty, tx, 0]]
+      // hat(t)*R: compute rows of hat(t) dotted with cols of R
+      double r00 = R.getM00(), r01 = R.getM01(), r02 = R.getM02();
+      double r10 = R.getM10(), r11 = R.getM11(), r12 = R.getM12();
+      double r20 = R.getM20(), r21 = R.getM21(), r22 = R.getM22();
+
+      // [hat(t)*R]_ij = sum_k hat(t)_ik * R_kj
+      // hat(t) row 0: [0, -tz, ty]
+      // hat(t) row 1: [tz,  0, -tx]
+      // hat(t) row 2: [-ty, tx,  0]
+      double ht00 = -tz * r10 + ty * r20;
+      double ht01 = -tz * r11 + ty * r21;
+      double ht02 = -tz * r12 + ty * r22;
+      double ht10 =  tz * r00 - tx * r20;
+      double ht11 =  tz * r01 - tx * r21;
+      double ht12 =  tz * r02 - tx * r22;
+      double ht20 = -ty * r00 + tx * r10;
+      double ht21 = -ty * r01 + tx * r11;
+      double ht22 = -ty * r02 + tx * r12;
+
+      // Top-left 3×3: R
+      adjToPack.unsafe_set(0, 0, r00); adjToPack.unsafe_set(0, 1, r01); adjToPack.unsafe_set(0, 2, r02);
+      adjToPack.unsafe_set(1, 0, r10); adjToPack.unsafe_set(1, 1, r11); adjToPack.unsafe_set(1, 2, r12);
+      adjToPack.unsafe_set(2, 0, r20); adjToPack.unsafe_set(2, 1, r21); adjToPack.unsafe_set(2, 2, r22);
+
+      // Top-right 3×3: hat(t)*R
+      adjToPack.unsafe_set(0, 3, ht00); adjToPack.unsafe_set(0, 4, ht01); adjToPack.unsafe_set(0, 5, ht02);
+      adjToPack.unsafe_set(1, 3, ht10); adjToPack.unsafe_set(1, 4, ht11); adjToPack.unsafe_set(1, 5, ht12);
+      adjToPack.unsafe_set(2, 3, ht20); adjToPack.unsafe_set(2, 4, ht21); adjToPack.unsafe_set(2, 5, ht22);
+
+      // Bottom-left 3×3: 0
+      adjToPack.unsafe_set(3, 0, 0.0); adjToPack.unsafe_set(3, 1, 0.0); adjToPack.unsafe_set(3, 2, 0.0);
+      adjToPack.unsafe_set(4, 0, 0.0); adjToPack.unsafe_set(4, 1, 0.0); adjToPack.unsafe_set(4, 2, 0.0);
+      adjToPack.unsafe_set(5, 0, 0.0); adjToPack.unsafe_set(5, 1, 0.0); adjToPack.unsafe_set(5, 2, 0.0);
+
+      // Bottom-right 3×3: R
+      adjToPack.unsafe_set(3, 3, r00); adjToPack.unsafe_set(3, 4, r01); adjToPack.unsafe_set(3, 5, r02);
+      adjToPack.unsafe_set(4, 3, r10); adjToPack.unsafe_set(4, 4, r11); adjToPack.unsafe_set(4, 5, r12);
+      adjToPack.unsafe_set(5, 3, r20); adjToPack.unsafe_set(5, 4, r21); adjToPack.unsafe_set(5, 5, r22);
+   }
+
+   /**
+    * Algebra adjoint (small adjoint) ad_ξ (6×6) for ξ = [ρ; φ].
+    *
+    * <pre>
+    *   ad_ξ = [ hat(φ)   hat(ρ) ]
+    *          [   0      hat(φ) ]
+    * </pre>
+    *
+    * @param xi         6-element array [ρx, ρy, ρz, φx, φy, φz]. Not modified.
+    * @param adToPack   6×6 DMatrixRMaj to pack ad_ξ into (must be at least 6×6). Modified.
+    */
+   public static void smallAdjoint(double[] xi, DMatrixRMaj adToPack)
+   {
+      double rhoX = xi[0], rhoY = xi[1], rhoZ = xi[2];
+      double phiX = xi[3], phiY = xi[4], phiZ = xi[5];
+
+      // hat(phi) = [[0, -phiZ, phiY], [phiZ, 0, -phiX], [-phiY, phiX, 0]]
+      // hat(rho) = [[0, -rhoZ, rhoY], [rhoZ, 0, -rhoX], [-rhoY, rhoX, 0]]
+
+      // Top-left 3×3: hat(phi)
+      adToPack.unsafe_set(0, 0, 0.0);    adToPack.unsafe_set(0, 1, -phiZ); adToPack.unsafe_set(0, 2, phiY);
+      adToPack.unsafe_set(1, 0, phiZ);   adToPack.unsafe_set(1, 1, 0.0);   adToPack.unsafe_set(1, 2, -phiX);
+      adToPack.unsafe_set(2, 0, -phiY);  adToPack.unsafe_set(2, 1, phiX);  adToPack.unsafe_set(2, 2, 0.0);
+
+      // Top-right 3×3: hat(rho)
+      adToPack.unsafe_set(0, 3, 0.0);    adToPack.unsafe_set(0, 4, -rhoZ); adToPack.unsafe_set(0, 5, rhoY);
+      adToPack.unsafe_set(1, 3, rhoZ);   adToPack.unsafe_set(1, 4, 0.0);   adToPack.unsafe_set(1, 5, -rhoX);
+      adToPack.unsafe_set(2, 3, -rhoY);  adToPack.unsafe_set(2, 4, rhoX);  adToPack.unsafe_set(2, 5, 0.0);
+
+      // Bottom-left 3×3: 0
+      adToPack.unsafe_set(3, 0, 0.0); adToPack.unsafe_set(3, 1, 0.0); adToPack.unsafe_set(3, 2, 0.0);
+      adToPack.unsafe_set(4, 0, 0.0); adToPack.unsafe_set(4, 1, 0.0); adToPack.unsafe_set(4, 2, 0.0);
+      adToPack.unsafe_set(5, 0, 0.0); adToPack.unsafe_set(5, 1, 0.0); adToPack.unsafe_set(5, 2, 0.0);
+
+      // Bottom-right 3×3: hat(phi)
+      adToPack.unsafe_set(3, 3, 0.0);    adToPack.unsafe_set(3, 4, -phiZ); adToPack.unsafe_set(3, 5, phiY);
+      adToPack.unsafe_set(4, 3, phiZ);   adToPack.unsafe_set(4, 4, 0.0);   adToPack.unsafe_set(4, 5, -phiX);
+      adToPack.unsafe_set(5, 3, -phiY);  adToPack.unsafe_set(5, 4, phiX);  adToPack.unsafe_set(5, 5, 0.0);
+   }
+}

--- a/src/main/java/us/ihmc/euclid/lieGroup/SE3LieGroupTools.java
+++ b/src/main/java/us/ihmc/euclid/lieGroup/SE3LieGroupTools.java
@@ -4,9 +4,12 @@ import org.ejml.data.DMatrixRMaj;
 
 import us.ihmc.euclid.matrix.Matrix3D;
 import us.ihmc.euclid.matrix.RotationMatrix;
+import us.ihmc.euclid.matrix.interfaces.Matrix3DBasics;
+import us.ihmc.euclid.matrix.interfaces.RotationMatrixBasics;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformBasics;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
 import us.ihmc.euclid.tuple3D.Vector3D;
+import us.ihmc.euclid.tuple3D.interfaces.Vector3DBasics;
 
 /**
  * Static utility class providing SE(3) Lie group and Lie algebra operations.
@@ -34,9 +37,17 @@ import us.ihmc.euclid.tuple3D.Vector3D;
  * </pre>
  * </p>
  *
- * <p>Allocation note: {@link #exp}, {@link #log}, {@link #adjoint}, and
- * {@link #smallAdjoint} allocate small temporaries. They are <em>not</em> suitable
- * for hard real-time loops without pre-allocation wrappers.</p>
+ * <p>Allocation note: {@link #hat}, {@link #vee}, and {@link #smallAdjoint} are allocation-free —
+ * they only write into the caller's output. {@link #exp}, {@link #log}, and {@link #adjoint} need
+ * intermediate 3D quantities, so each comes in two flavors:
+ * <ul>
+ *   <li>a convenience overload that creates those intermediates itself — fine for tests and other
+ *       non-real-time callers;</li>
+ *   <li>an allocation-free overload that takes them as parameters, so a per-tick caller can hold
+ *       them as fields and reuse them. They are inputs only in the sense that the caller supplies
+ *       the objects; their contents are overwritten and carry no meaning between calls.</li>
+ * </ul>
+ * The allocation-free overloads are covered by {@code SE3LieGroupToolsTest.testAllocationFree}.</p>
  */
 public class SE3LieGroupTools
 {
@@ -119,20 +130,34 @@ public class SE3LieGroupTools
     */
    public static void exp(double[] xi, RigidBodyTransformBasics transformToPack)
    {
-      Vector3D phi = new Vector3D(xi[0], xi[1], xi[2]);
+      exp(xi, transformToPack, new Vector3D(), new Matrix3D());
+   }
 
-      RotationMatrix R = new RotationMatrix();
-      SO3LieGroupTools.exp(phi, R);
+   /**
+    * Allocation-free {@link #exp(double[], RigidBodyTransformBasics)}: the caller supplies the two
+    * intermediates so a per-tick caller can hold them as fields instead of allocating per call.
+    *
+    * @param xi              6-element array [φx, φy, φz, ρx, ρy, ρz]. Not modified.
+    * @param transformToPack the rigid-body transform to pack the result into. Modified.
+    * @param phi             holds the rotation part φ. Contents overwritten; caller-supplied only to
+    *                        avoid the allocation.
+    * @param leftJacobian    holds the left Jacobian J_l(φ). Contents overwritten; caller-supplied
+    *                        only to avoid the allocation.
+    */
+   public static void exp(double[] xi, RigidBodyTransformBasics transformToPack, Vector3DBasics phi, Matrix3DBasics leftJacobian)
+   {
+      phi.set(xi[0], xi[1], xi[2]);
 
-      Matrix3D Jl = new Matrix3D();
-      SO3LieGroupTools.leftJacobian(phi, Jl);
+      // Exponentiate straight into the target orientation rather than into an intermediate rotation
+      // matrix: one less temporary, and a quaternion-backed transform never round-trips through a DCM.
+      SO3LieGroupTools.exp(phi, transformToPack.getRotation());
+      SO3LieGroupTools.leftJacobian(phi, leftJacobian);
 
       double rhoX = xi[3], rhoY = xi[4], rhoZ = xi[5];
-      double tx = Jl.getM00() * rhoX + Jl.getM01() * rhoY + Jl.getM02() * rhoZ;
-      double ty = Jl.getM10() * rhoX + Jl.getM11() * rhoY + Jl.getM12() * rhoZ;
-      double tz = Jl.getM20() * rhoX + Jl.getM21() * rhoY + Jl.getM22() * rhoZ;
+      double tx = leftJacobian.getM00() * rhoX + leftJacobian.getM01() * rhoY + leftJacobian.getM02() * rhoZ;
+      double ty = leftJacobian.getM10() * rhoX + leftJacobian.getM11() * rhoY + leftJacobian.getM12() * rhoZ;
+      double tz = leftJacobian.getM20() * rhoX + leftJacobian.getM21() * rhoY + leftJacobian.getM22() * rhoZ;
 
-      transformToPack.getRotation().set(R);
       transformToPack.getTranslation().set(tx, ty, tz);
    }
 
@@ -146,11 +171,24 @@ public class SE3LieGroupTools
     */
    public static void log(RigidBodyTransformReadOnly transform, double[] xiToPack)
    {
-      Vector3D phi = new Vector3D();
-      SO3LieGroupTools.log(transform.getRotation(), phi);
+      log(transform, xiToPack, new Vector3D(), new Matrix3D());
+   }
 
-      Matrix3D JlInv = new Matrix3D();
-      SO3LieGroupTools.leftJacobianInverse(phi, JlInv);
+   /**
+    * Allocation-free {@link #log(RigidBodyTransformReadOnly, double[])}: the caller supplies the two
+    * intermediates so a per-tick caller can hold them as fields instead of allocating per call.
+    *
+    * @param transform           the rigid-body transform. Not modified.
+    * @param xiToPack            6-element array to pack [φx, φy, φz, ρx, ρy, ρz] into. Modified.
+    * @param phi                 holds the rotation part φ. Contents overwritten; caller-supplied only
+    *                            to avoid the allocation.
+    * @param leftJacobianInverse holds the inverse left Jacobian J_l⁻¹(φ). Contents overwritten;
+    *                            caller-supplied only to avoid the allocation.
+    */
+   public static void log(RigidBodyTransformReadOnly transform, double[] xiToPack, Vector3DBasics phi, Matrix3DBasics leftJacobianInverse)
+   {
+      SO3LieGroupTools.log(transform.getRotation(), phi);
+      SO3LieGroupTools.leftJacobianInverse(phi, leftJacobianInverse);
 
       double tx = transform.getTranslation().getX();
       double ty = transform.getTranslation().getY();
@@ -159,9 +197,9 @@ public class SE3LieGroupTools
       xiToPack[0] = phi.getX();
       xiToPack[1] = phi.getY();
       xiToPack[2] = phi.getZ();
-      xiToPack[3] = JlInv.getM00() * tx + JlInv.getM01() * ty + JlInv.getM02() * tz;
-      xiToPack[4] = JlInv.getM10() * tx + JlInv.getM11() * ty + JlInv.getM12() * tz;
-      xiToPack[5] = JlInv.getM20() * tx + JlInv.getM21() * ty + JlInv.getM22() * tz;
+      xiToPack[3] = leftJacobianInverse.getM00() * tx + leftJacobianInverse.getM01() * ty + leftJacobianInverse.getM02() * tz;
+      xiToPack[4] = leftJacobianInverse.getM10() * tx + leftJacobianInverse.getM11() * ty + leftJacobianInverse.getM12() * tz;
+      xiToPack[5] = leftJacobianInverse.getM20() * tx + leftJacobianInverse.getM21() * ty + leftJacobianInverse.getM22() * tz;
    }
 
    // -----------------------------------------------------------------------
@@ -181,8 +219,26 @@ public class SE3LieGroupTools
     */
    public static void adjoint(RigidBodyTransformReadOnly transform, DMatrixRMaj adjToPack)
    {
-      RotationMatrix R = new RotationMatrix();
-      R.set(transform.getRotation());
+      adjoint(transform, adjToPack, new RotationMatrix());
+   }
+
+   /**
+    * Allocation-free {@link #adjoint(RigidBodyTransformReadOnly, DMatrixRMaj)}: the caller supplies
+    * the intermediate so a per-tick caller can hold it as a field instead of allocating per call.
+    *
+    * <p>This one is unavoidable rather than merely convenient:
+    * {@link RigidBodyTransformReadOnly#getRotation()} returns an {@code Orientation3DReadOnly}, which
+    * may be quaternion- or axis-angle-backed and exposes no matrix elements, so the orientation has
+    * to be materialized as a rotation matrix before R's nine components can be read.</p>
+    *
+    * @param transform the SE(3) element T. Not modified.
+    * @param adjToPack 6×6 DMatrixRMaj to pack Ad_T into (must be at least 6×6). Modified.
+    * @param rotation  receives T's rotation R. Contents overwritten; caller-supplied only to avoid
+    *                  the allocation.
+    */
+   public static void adjoint(RigidBodyTransformReadOnly transform, DMatrixRMaj adjToPack, RotationMatrixBasics rotation)
+   {
+      rotation.set(transform.getRotation());
 
       double tx = transform.getTranslation().getX();
       double ty = transform.getTranslation().getY();
@@ -190,9 +246,9 @@ public class SE3LieGroupTools
 
       // hat(t) = [[0, -tz, ty], [tz, 0, -tx], [-ty, tx, 0]]
       // hat(t)*R: compute rows of hat(t) dotted with cols of R
-      double r00 = R.getM00(), r01 = R.getM01(), r02 = R.getM02();
-      double r10 = R.getM10(), r11 = R.getM11(), r12 = R.getM12();
-      double r20 = R.getM20(), r21 = R.getM21(), r22 = R.getM22();
+      double r00 = rotation.getM00(), r01 = rotation.getM01(), r02 = rotation.getM02();
+      double r10 = rotation.getM10(), r11 = rotation.getM11(), r12 = rotation.getM12();
+      double r20 = rotation.getM20(), r21 = rotation.getM21(), r22 = rotation.getM22();
 
       // [hat(t)*R]_ij = sum_k hat(t)_ik * R_kj
       // hat(t) row 0: [0, -tz, ty]

--- a/src/main/java/us/ihmc/euclid/lieGroup/SE3LieGroupTools.java
+++ b/src/main/java/us/ihmc/euclid/lieGroup/SE3LieGroupTools.java
@@ -12,10 +12,10 @@ import us.ihmc.euclid.tuple3D.Vector3D;
  * Static utility class providing SE(3) Lie group and Lie algebra operations.
  *
  * <p>The Lie algebra se(3) is identified with ℝ⁶ via the hat/vee isomorphism.
- * The 6-vector convention is {@code ξ = [ρ; φ]} where:
+ * The 6-vector convention is {@code ξ = [φ; ρ]} where:
  * <ul>
- *   <li>ρ = xi[0..2] — translational (linear) component</li>
- *   <li>φ = xi[3..5] — rotational (angular) component</li>
+ *   <li>φ = xi[0..2] — rotational (angular) component</li>
+ *   <li>ρ = xi[3..5] — translational (linear) component</li>
  * </ul>
  * </p>
  *
@@ -27,10 +27,10 @@ import us.ihmc.euclid.tuple3D.Vector3D;
  * </pre>
  * </p>
  *
- * <p>The SE(3) group adjoint (6×6) for T = (R, t) with 6-vector ordering [ρ; φ] is:
+ * <p>The SE(3) group adjoint (6×6) for T = (R, t) with 6-vector ordering [φ; ρ] is:
  * <pre>
- *   Ad_T = [ R    hat(t)·R ]
- *          [ 0       R     ]
+ *   Ad_T = [    R     0 ]
+ *          [ hat(t)·R R ]
  * </pre>
  * </p>
  *
@@ -49,10 +49,10 @@ public class SE3LieGroupTools
    // -----------------------------------------------------------------------
 
    /**
-    * SE(3) hat map: converts a 6-vector ξ = [ρ; φ] to a 4×4 se(3) matrix.
+    * SE(3) hat map: converts a 6-vector ξ = [φ; ρ] to a 4×4 se(3) matrix.
     *
     * <pre>
-    * xi[0..2] = ρ (translation part),  xi[3..5] = φ (rotation part)
+    * xi[0..2] = φ (rotation part),  xi[3..5] = ρ (translation part)
     *
     *            [  0   -φz   φy   ρx ]
     *            [ φz    0   -φx   ρy ]
@@ -60,13 +60,13 @@ public class SE3LieGroupTools
     *            [  0    0    0     0  ]
     * </pre>
     *
-    * @param xi          6-element array [ρx, ρy, ρz, φx, φy, φz]. Not modified.
+    * @param xi          6-element array [φx, φy, φz, ρx, ρy, ρz]. Not modified.
     * @param matrixToPack 4×4 matrix to pack the result into (must be at least 4×4). Modified.
     */
    public static void hat(double[] xi, DMatrixRMaj matrixToPack)
    {
-      double rhoX = xi[0], rhoY = xi[1], rhoZ = xi[2];
-      double phiX = xi[3], phiY = xi[4], phiZ = xi[5];
+      double phiX = xi[0], phiY = xi[1], phiZ = xi[2];
+      double rhoX = xi[3], rhoY = xi[4], rhoZ = xi[5];
 
       matrixToPack.unsafe_set(0, 0, 0.0);
       matrixToPack.unsafe_set(0, 1, -phiZ);
@@ -90,19 +90,19 @@ public class SE3LieGroupTools
    }
 
    /**
-    * SE(3) vee map: extracts the 6-vector ξ = [ρ; φ] from a 4×4 se(3) hat matrix.
+    * SE(3) vee map: extracts the 6-vector ξ = [φ; ρ] from a 4×4 se(3) hat matrix.
     *
     * @param hatMatrix  4×4 se(3) hat matrix. Not modified.
-    * @param xiToPack   6-element array to pack [ρx, ρy, ρz, φx, φy, φz] into. Modified.
+    * @param xiToPack   6-element array to pack [φx, φy, φz, ρx, ρy, ρz] into. Modified.
     */
    public static void vee(DMatrixRMaj hatMatrix, double[] xiToPack)
    {
-      xiToPack[0] = hatMatrix.unsafe_get(0, 3); // ρx
-      xiToPack[1] = hatMatrix.unsafe_get(1, 3); // ρy
-      xiToPack[2] = hatMatrix.unsafe_get(2, 3); // ρz
-      xiToPack[3] = hatMatrix.unsafe_get(2, 1); // φx
-      xiToPack[4] = hatMatrix.unsafe_get(0, 2); // φy
-      xiToPack[5] = hatMatrix.unsafe_get(1, 0); // φz
+      xiToPack[0] = hatMatrix.unsafe_get(2, 1); // φx
+      xiToPack[1] = hatMatrix.unsafe_get(0, 2); // φy
+      xiToPack[2] = hatMatrix.unsafe_get(1, 0); // φz
+      xiToPack[3] = hatMatrix.unsafe_get(0, 3); // ρx
+      xiToPack[4] = hatMatrix.unsafe_get(1, 3); // ρy
+      xiToPack[5] = hatMatrix.unsafe_get(2, 3); // ρz
    }
 
    // -----------------------------------------------------------------------
@@ -110,16 +110,16 @@ public class SE3LieGroupTools
    // -----------------------------------------------------------------------
 
    /**
-    * SE(3) exponential map: converts a Lie algebra element ξ = [ρ; φ] to a rigid-body transform.
+    * SE(3) exponential map: converts a Lie algebra element ξ = [φ; ρ] to a rigid-body transform.
     *
     * <p>Formula: R = exp(hat(φ)), t = J_l(φ) · ρ.</p>
     *
-    * @param xi          6-element array [ρx, ρy, ρz, φx, φy, φz]. Not modified.
+    * @param xi          6-element array [φx, φy, φz, ρx, ρy, ρz]. Not modified.
     * @param transformToPack the rigid-body transform to pack the result into. Modified.
     */
    public static void exp(double[] xi, RigidBodyTransformBasics transformToPack)
    {
-      Vector3D phi = new Vector3D(xi[3], xi[4], xi[5]);
+      Vector3D phi = new Vector3D(xi[0], xi[1], xi[2]);
 
       RotationMatrix R = new RotationMatrix();
       SO3LieGroupTools.exp(phi, R);
@@ -127,7 +127,7 @@ public class SE3LieGroupTools
       Matrix3D Jl = new Matrix3D();
       SO3LieGroupTools.leftJacobian(phi, Jl);
 
-      double rhoX = xi[0], rhoY = xi[1], rhoZ = xi[2];
+      double rhoX = xi[3], rhoY = xi[4], rhoZ = xi[5];
       double tx = Jl.getM00() * rhoX + Jl.getM01() * rhoY + Jl.getM02() * rhoZ;
       double ty = Jl.getM10() * rhoX + Jl.getM11() * rhoY + Jl.getM12() * rhoZ;
       double tz = Jl.getM20() * rhoX + Jl.getM21() * rhoY + Jl.getM22() * rhoZ;
@@ -137,12 +137,12 @@ public class SE3LieGroupTools
    }
 
    /**
-    * SE(3) logarithmic map: converts a rigid-body transform to its Lie algebra element ξ = [ρ; φ].
+    * SE(3) logarithmic map: converts a rigid-body transform to its Lie algebra element ξ = [φ; ρ].
     *
     * <p>Formula: φ = log(R), ρ = J_l⁻¹(φ) · t.</p>
     *
     * @param transform  the rigid-body transform. Not modified.
-    * @param xiToPack   6-element array to pack [ρx, ρy, ρz, φx, φy, φz] into. Modified.
+    * @param xiToPack   6-element array to pack [φx, φy, φz, ρx, ρy, ρz] into. Modified.
     */
    public static void log(RigidBodyTransformReadOnly transform, double[] xiToPack)
    {
@@ -156,12 +156,12 @@ public class SE3LieGroupTools
       double ty = transform.getTranslation().getY();
       double tz = transform.getTranslation().getZ();
 
-      xiToPack[0] = JlInv.getM00() * tx + JlInv.getM01() * ty + JlInv.getM02() * tz;
-      xiToPack[1] = JlInv.getM10() * tx + JlInv.getM11() * ty + JlInv.getM12() * tz;
-      xiToPack[2] = JlInv.getM20() * tx + JlInv.getM21() * ty + JlInv.getM22() * tz;
-      xiToPack[3] = phi.getX();
-      xiToPack[4] = phi.getY();
-      xiToPack[5] = phi.getZ();
+      xiToPack[0] = phi.getX();
+      xiToPack[1] = phi.getY();
+      xiToPack[2] = phi.getZ();
+      xiToPack[3] = JlInv.getM00() * tx + JlInv.getM01() * ty + JlInv.getM02() * tz;
+      xiToPack[4] = JlInv.getM10() * tx + JlInv.getM11() * ty + JlInv.getM12() * tz;
+      xiToPack[5] = JlInv.getM20() * tx + JlInv.getM21() * ty + JlInv.getM22() * tz;
    }
 
    // -----------------------------------------------------------------------
@@ -169,11 +169,11 @@ public class SE3LieGroupTools
    // -----------------------------------------------------------------------
 
    /**
-    * Group adjoint Ad_T (6×6) for T = (R, t), with 6-vector ordering [ρ; φ].
+    * Group adjoint Ad_T (6×6) for T = (R, t), with 6-vector ordering [φ; ρ].
     *
     * <pre>
-    *   Ad_T = [ R    hat(t)·R ]
-    *          [ 0       R     ]
+    *   Ad_T = [    R     0 ]
+    *          [ hat(t)·R R ]
     * </pre>
     *
     * @param transform    the SE(3) element T. Not modified.
@@ -213,15 +213,15 @@ public class SE3LieGroupTools
       adjToPack.unsafe_set(1, 0, r10); adjToPack.unsafe_set(1, 1, r11); adjToPack.unsafe_set(1, 2, r12);
       adjToPack.unsafe_set(2, 0, r20); adjToPack.unsafe_set(2, 1, r21); adjToPack.unsafe_set(2, 2, r22);
 
-      // Top-right 3×3: hat(t)*R
-      adjToPack.unsafe_set(0, 3, ht00); adjToPack.unsafe_set(0, 4, ht01); adjToPack.unsafe_set(0, 5, ht02);
-      adjToPack.unsafe_set(1, 3, ht10); adjToPack.unsafe_set(1, 4, ht11); adjToPack.unsafe_set(1, 5, ht12);
-      adjToPack.unsafe_set(2, 3, ht20); adjToPack.unsafe_set(2, 4, ht21); adjToPack.unsafe_set(2, 5, ht22);
+      // Top-right 3×3: 0
+      adjToPack.unsafe_set(0, 3, 0.0); adjToPack.unsafe_set(0, 4, 0.0); adjToPack.unsafe_set(0, 5, 0.0);
+      adjToPack.unsafe_set(1, 3, 0.0); adjToPack.unsafe_set(1, 4, 0.0); adjToPack.unsafe_set(1, 5, 0.0);
+      adjToPack.unsafe_set(2, 3, 0.0); adjToPack.unsafe_set(2, 4, 0.0); adjToPack.unsafe_set(2, 5, 0.0);
 
-      // Bottom-left 3×3: 0
-      adjToPack.unsafe_set(3, 0, 0.0); adjToPack.unsafe_set(3, 1, 0.0); adjToPack.unsafe_set(3, 2, 0.0);
-      adjToPack.unsafe_set(4, 0, 0.0); adjToPack.unsafe_set(4, 1, 0.0); adjToPack.unsafe_set(4, 2, 0.0);
-      adjToPack.unsafe_set(5, 0, 0.0); adjToPack.unsafe_set(5, 1, 0.0); adjToPack.unsafe_set(5, 2, 0.0);
+      // Bottom-left 3×3: hat(t)*R
+      adjToPack.unsafe_set(3, 0, ht00); adjToPack.unsafe_set(3, 1, ht01); adjToPack.unsafe_set(3, 2, ht02);
+      adjToPack.unsafe_set(4, 0, ht10); adjToPack.unsafe_set(4, 1, ht11); adjToPack.unsafe_set(4, 2, ht12);
+      adjToPack.unsafe_set(5, 0, ht20); adjToPack.unsafe_set(5, 1, ht21); adjToPack.unsafe_set(5, 2, ht22);
 
       // Bottom-right 3×3: R
       adjToPack.unsafe_set(3, 3, r00); adjToPack.unsafe_set(3, 4, r01); adjToPack.unsafe_set(3, 5, r02);
@@ -230,20 +230,20 @@ public class SE3LieGroupTools
    }
 
    /**
-    * Algebra adjoint (small adjoint) ad_ξ (6×6) for ξ = [ρ; φ].
+    * Algebra adjoint (small adjoint) ad_ξ (6×6) for ξ = [φ; ρ].
     *
     * <pre>
-    *   ad_ξ = [ hat(φ)   hat(ρ) ]
-    *          [   0      hat(φ) ]
+    *   ad_ξ = [ hat(φ)     0    ]
+    *          [ hat(ρ)   hat(φ) ]
     * </pre>
     *
-    * @param xi         6-element array [ρx, ρy, ρz, φx, φy, φz]. Not modified.
+    * @param xi         6-element array [φx, φy, φz, ρx, ρy, ρz]. Not modified.
     * @param adToPack   6×6 DMatrixRMaj to pack ad_ξ into (must be at least 6×6). Modified.
     */
    public static void smallAdjoint(double[] xi, DMatrixRMaj adToPack)
    {
-      double rhoX = xi[0], rhoY = xi[1], rhoZ = xi[2];
-      double phiX = xi[3], phiY = xi[4], phiZ = xi[5];
+      double phiX = xi[0], phiY = xi[1], phiZ = xi[2];
+      double rhoX = xi[3], rhoY = xi[4], rhoZ = xi[5];
 
       // hat(phi) = [[0, -phiZ, phiY], [phiZ, 0, -phiX], [-phiY, phiX, 0]]
       // hat(rho) = [[0, -rhoZ, rhoY], [rhoZ, 0, -rhoX], [-rhoY, rhoX, 0]]
@@ -253,15 +253,15 @@ public class SE3LieGroupTools
       adToPack.unsafe_set(1, 0, phiZ);   adToPack.unsafe_set(1, 1, 0.0);   adToPack.unsafe_set(1, 2, -phiX);
       adToPack.unsafe_set(2, 0, -phiY);  adToPack.unsafe_set(2, 1, phiX);  adToPack.unsafe_set(2, 2, 0.0);
 
-      // Top-right 3×3: hat(rho)
-      adToPack.unsafe_set(0, 3, 0.0);    adToPack.unsafe_set(0, 4, -rhoZ); adToPack.unsafe_set(0, 5, rhoY);
-      adToPack.unsafe_set(1, 3, rhoZ);   adToPack.unsafe_set(1, 4, 0.0);   adToPack.unsafe_set(1, 5, -rhoX);
-      adToPack.unsafe_set(2, 3, -rhoY);  adToPack.unsafe_set(2, 4, rhoX);  adToPack.unsafe_set(2, 5, 0.0);
+      // Top-right 3×3: 0
+      adToPack.unsafe_set(0, 3, 0.0); adToPack.unsafe_set(0, 4, 0.0); adToPack.unsafe_set(0, 5, 0.0);
+      adToPack.unsafe_set(1, 3, 0.0); adToPack.unsafe_set(1, 4, 0.0); adToPack.unsafe_set(1, 5, 0.0);
+      adToPack.unsafe_set(2, 3, 0.0); adToPack.unsafe_set(2, 4, 0.0); adToPack.unsafe_set(2, 5, 0.0);
 
-      // Bottom-left 3×3: 0
-      adToPack.unsafe_set(3, 0, 0.0); adToPack.unsafe_set(3, 1, 0.0); adToPack.unsafe_set(3, 2, 0.0);
-      adToPack.unsafe_set(4, 0, 0.0); adToPack.unsafe_set(4, 1, 0.0); adToPack.unsafe_set(4, 2, 0.0);
-      adToPack.unsafe_set(5, 0, 0.0); adToPack.unsafe_set(5, 1, 0.0); adToPack.unsafe_set(5, 2, 0.0);
+      // Bottom-left 3×3: hat(rho)
+      adToPack.unsafe_set(3, 0, 0.0);    adToPack.unsafe_set(3, 1, -rhoZ); adToPack.unsafe_set(3, 2, rhoY);
+      adToPack.unsafe_set(4, 0, rhoZ);   adToPack.unsafe_set(4, 1, 0.0);   adToPack.unsafe_set(4, 2, -rhoX);
+      adToPack.unsafe_set(5, 0, -rhoY);  adToPack.unsafe_set(5, 1, rhoX);  adToPack.unsafe_set(5, 2, 0.0);
 
       // Bottom-right 3×3: hat(phi)
       adToPack.unsafe_set(3, 3, 0.0);    adToPack.unsafe_set(3, 4, -phiZ); adToPack.unsafe_set(3, 5, phiY);

--- a/src/main/java/us/ihmc/euclid/lieGroup/SO3LieGroupTools.java
+++ b/src/main/java/us/ihmc/euclid/lieGroup/SO3LieGroupTools.java
@@ -81,6 +81,7 @@ public class SO3LieGroupTools
     * @param omega             rotation vector (axis scaled by angle). Not modified.
     * @param orientationToPack the orientation to pack the result into. Modified.
     */
+   // Equivalent of \Gamma_0
    public static void exp(Vector3DReadOnly omega, Orientation3DBasics orientationToPack)
    {
       Quaternion q = new Quaternion();
@@ -132,7 +133,7 @@ public class SO3LieGroupTools
    // -----------------------------------------------------------------------
 
    /**
-    * Left Jacobian of SO(3), J_l(ω).
+    * Left Jacobian of SO(3), J_l(ω). Equivalent to \Gamma_1.
     *
     * <p>Closed-form (θ = ‖ω‖, n̂ = ω/θ):
     * <pre>
@@ -302,4 +303,62 @@ public class SO3LieGroupTools
                        omhtc * ny * nx + halfTheta * nz,  htCot + omhtc * ny * ny,        omhtc * ny * nz - halfTheta * nx,
                        omhtc * nz * nx - halfTheta * ny,  omhtc * nz * ny + halfTheta * nx,  htCot + omhtc * nz * nz);
    }
+
+   /**
+    * Packs M = a·I + b·hat(ω) + c·ωωᵀ into matrixToPack.
+    * The Γ_m functions and the SO(3) Jacobians all share this structure,
+    * because hat(ω)² = ωωᵀ − ‖ω‖²·I collapses any φ̂ power series to these three terms.
+    */
+   private static void setIPlusSkewOuter(double a, double b, double c,
+                                         double wx, double wy, double wz,
+                                         Matrix3DBasics matrixToPack)
+   {
+      matrixToPack.set(a + c * wx * wx,      c * wx * wy - b * wz,  c * wx * wz + b * wy,
+                       c * wy * wx + b * wz, a + c * wy * wy,       c * wy * wz - b * wx,
+                       c * wz * wx - b * wy, c * wz * wy + b * wx,  a + c * wz * wz);
+   }
+
+
+   /**
+    * Third SO(3) integration coefficient Γ₂(φ) = Σ_{n≥0} hat(φ)ⁿ / (n+2)!.
+    *
+    * <p>Closed-form (θ = ‖φ‖, Φ = hat(φ)):
+    * <pre>
+    *   Γ₂ = ½I + ((θ − sinθ)/θ³) Φ + ((θ² + 2cosθ − 2)/(2θ⁴)) Φ²
+    * </pre>
+    * Rewritten via Φ² = φφᵀ − θ²I into the a·I + b·hat + c·φφᵀ form.
+    * For θ &lt; EPS the coefficients use their Taylor series.</p>
+    *
+    * @param phi          the rotation vector φ. Not modified.
+    * @param matrixToPack the 3×3 matrix to pack Γ₂ into. Modified.
+    */
+   public static void gamma2(Vector3DReadOnly phi, Matrix3DBasics matrixToPack)
+   {
+      double wx = phi.getX();
+      double wy = phi.getY();
+      double wz = phi.getZ();
+
+      double theta2 = wx * wx + wy * wy + wz * wz;
+      double theta = Math.sqrt(theta2);
+
+      double b; // coefficient on \Phi: (\theta - \sin\theta)/\theta^3
+      double c; // coefficient on \Phi^2: (\theta^2+2\cos\theta - 2)(2\theta^4)
+
+      if (theta < EPS) // small angle approximation, disregard fourth order terms
+      {
+         b = 1.0 / 6.0 - theta2 / 120.0;
+         c = 1.0 / 24.0 - theta2 / 720.0;
+      }
+      else
+      {
+         double theta3 = theta * theta2;
+         double theta4 = theta2 * theta2;
+         b = (theta - Math.sin(theta)) / theta3;
+         c = (theta2 + 2.0 * Math.cos(theta) - 2.0) / (2.0 * theta4);
+      }
+
+      double a = 0.5 - c * theta2;
+      setIPlusSkewOuter(a, b, c, wx, wy, wz, matrixToPack);
+   }
+
 }

--- a/src/main/java/us/ihmc/euclid/lieGroup/SO3LieGroupTools.java
+++ b/src/main/java/us/ihmc/euclid/lieGroup/SO3LieGroupTools.java
@@ -4,10 +4,8 @@ import us.ihmc.euclid.matrix.interfaces.Matrix3DBasics;
 import us.ihmc.euclid.matrix.interfaces.Matrix3DReadOnly;
 import us.ihmc.euclid.orientation.interfaces.Orientation3DBasics;
 import us.ihmc.euclid.orientation.interfaces.Orientation3DReadOnly;
-import us.ihmc.euclid.rotationConversion.QuaternionConversion;
 import us.ihmc.euclid.tuple3D.interfaces.Vector3DBasics;
 import us.ihmc.euclid.tuple3D.interfaces.Vector3DReadOnly;
-import us.ihmc.euclid.tuple4D.Quaternion;
 
 /**
  * Static utility class providing SO(3) Lie group and Lie algebra operations.
@@ -84,9 +82,10 @@ public class SO3LieGroupTools
    // Equivalent of \Gamma_0
    public static void exp(Vector3DReadOnly omega, Orientation3DBasics orientationToPack)
    {
-      Quaternion q = new Quaternion();
-      QuaternionConversion.convertRotationVectorToQuaternion(omega, q);
-      orientationToPack.set(q);
+      // Allocation-free: write the rotation vector straight into the target orientation. This is the
+      // same exponential map as routing through a quaternion, but without the per-call Quaternion
+      // garbage — this method is on the estimator's per-tick hot path (SEK3_Utils, InvariantPropagator).
+      orientationToPack.setRotationVector(omega);
    }
 
    /**

--- a/src/main/java/us/ihmc/euclid/lieGroup/SO3LieGroupTools.java
+++ b/src/main/java/us/ihmc/euclid/lieGroup/SO3LieGroupTools.java
@@ -1,0 +1,305 @@
+package us.ihmc.euclid.lieGroup;
+
+import us.ihmc.euclid.matrix.interfaces.Matrix3DBasics;
+import us.ihmc.euclid.matrix.interfaces.Matrix3DReadOnly;
+import us.ihmc.euclid.orientation.interfaces.Orientation3DBasics;
+import us.ihmc.euclid.orientation.interfaces.Orientation3DReadOnly;
+import us.ihmc.euclid.rotationConversion.QuaternionConversion;
+import us.ihmc.euclid.tuple3D.interfaces.Vector3DBasics;
+import us.ihmc.euclid.tuple3D.interfaces.Vector3DReadOnly;
+import us.ihmc.euclid.tuple4D.Quaternion;
+
+/**
+ * Static utility class providing SO(3) Lie group and Lie algebra operations.
+ *
+ * <p>The Lie algebra so(3) is identified with ℝ³ via the hat/vee isomorphism.
+ * All methods are static; {@code ToPack} parameters are the outputs — inputs are never modified.</p>
+ *
+ * <p>Conventions:
+ * <ul>
+ *   <li>hat(ω) = skew-symmetric Ω such that Ω v = ω × v</li>
+ *   <li>exp(ω) maps a rotation vector (axis scaled by angle) to SO(3) via Rodrigues</li>
+ *   <li>log(R) maps an SO(3) element to its rotation vector ω with ‖ω‖ ∈ [0, π]</li>
+ *   <li>J_l denotes the <em>left</em> Jacobian of SO(3); J_r = J_l(-ω)</li>
+ * </ul>
+ * </p>
+ */
+public class SO3LieGroupTools
+{
+   /** Small-angle threshold below which series approximations are used. */
+   public static final double EPS = 1.0e-7;
+
+   private SO3LieGroupTools()
+   {
+   }
+
+   // -----------------------------------------------------------------------
+   // hat / vee
+   // -----------------------------------------------------------------------
+
+   /**
+    * Computes the hat (skew-symmetric) map: ω ↦ Ω where Ω v = ω × v.
+    *
+    * <pre>
+    *     [  0   -ωz   ωy ]
+    * Ω = [ ωz    0   -ωx ]
+    *     [-ωy   ωx    0  ]
+    * </pre>
+    *
+    * @param omega        the rotation vector ω. Not modified.
+    * @param matrixToPack the 3×3 matrix to pack the result into. Modified.
+    */
+   public static void hat(Vector3DReadOnly omega, Matrix3DBasics matrixToPack)
+   {
+      double wx = omega.getX();
+      double wy = omega.getY();
+      double wz = omega.getZ();
+      matrixToPack.set(0.0,  -wz,   wy,
+                        wz,  0.0,  -wx,
+                       -wy,   wx,  0.0);
+   }
+
+   /**
+    * Computes the vee map (inverse of hat): extracts ω from a skew-symmetric matrix Ω.
+    *
+    * @param skewMatrix   a skew-symmetric 3×3 matrix. Not modified.
+    * @param vectorToPack the vector to pack ω into. Modified.
+    */
+   public static void vee(Matrix3DReadOnly skewMatrix, Vector3DBasics vectorToPack)
+   {
+      // hat(ω)[2,1] = ωx,  hat(ω)[0,2] = ωy,  hat(ω)[1,0] = ωz
+      vectorToPack.set(skewMatrix.getM21(), skewMatrix.getM02(), skewMatrix.getM10());
+   }
+
+   // -----------------------------------------------------------------------
+   // exp / log
+   // -----------------------------------------------------------------------
+
+   /**
+    * SO(3) exponential map: converts a rotation vector ω (axis × angle) to an orientation.
+    *
+    * @param omega             rotation vector (axis scaled by angle). Not modified.
+    * @param orientationToPack the orientation to pack the result into. Modified.
+    */
+   public static void exp(Vector3DReadOnly omega, Orientation3DBasics orientationToPack)
+   {
+      Quaternion q = new Quaternion();
+      QuaternionConversion.convertRotationVectorToQuaternion(omega, q);
+      orientationToPack.set(q);
+   }
+
+   /**
+    * SO(3) logarithmic map: converts an orientation R to its rotation vector ω = axis × angle.
+    *
+    * @param rotation     the SO(3) element. Not modified.
+    * @param vectorToPack the vector to pack ω into. Modified.
+    */
+   public static void log(Orientation3DReadOnly rotation, Vector3DBasics vectorToPack)
+   {
+      rotation.getRotationVector(vectorToPack);
+   }
+
+   // -----------------------------------------------------------------------
+   // Adjoint representations
+   // -----------------------------------------------------------------------
+
+   /**
+    * Group adjoint Ad_R: for SO(3), Ad_R = R (the rotation matrix),
+    * since Ad_R ω = R ω when so(3) ≅ ℝ³.
+    *
+    * @param rotation     the SO(3) element. Not modified.
+    * @param matrixToPack the 3×3 matrix to pack Ad_R into. Modified.
+    */
+   public static void adjoint(Orientation3DReadOnly rotation, Matrix3DBasics matrixToPack)
+   {
+      matrixToPack.set(rotation);
+   }
+
+   /**
+    * Algebra adjoint (small adjoint) ad_ω: the Lie bracket map ξ ↦ ω × ξ on so(3).
+    * ad_ω = hat(ω).
+    *
+    * @param omega        the algebra element ω. Not modified.
+    * @param matrixToPack the 3×3 matrix to pack ad_ω into. Modified.
+    */
+   public static void smallAdjoint(Vector3DReadOnly omega, Matrix3DBasics matrixToPack)
+   {
+      hat(omega, matrixToPack);
+   }
+
+   // -----------------------------------------------------------------------
+   // Left / right Jacobians
+   // -----------------------------------------------------------------------
+
+   /**
+    * Left Jacobian of SO(3), J_l(ω).
+    *
+    * <p>Closed-form (θ = ‖ω‖, n̂ = ω/θ):
+    * <pre>
+    *   J_l = (sinθ/θ) I  +  (1 − sinθ/θ) n̂n̂ᵀ  +  ((1−cosθ)/θ) hat(n̂)
+    * </pre>
+    * For θ &lt; EPS uses: J_l ≈ (1 − θ²/6) I + ½ hat(ω) + (1/6) ω ωᵀ.</p>
+    *
+    * @param omega        the rotation vector ω. Not modified.
+    * @param matrixToPack the 3×3 matrix to pack J_l into. Modified.
+    */
+   public static void leftJacobian(Vector3DReadOnly omega, Matrix3DBasics matrixToPack)
+   {
+      double wx = omega.getX();
+      double wy = omega.getY();
+      double wz = omega.getZ();
+      double theta2 = wx * wx + wy * wy + wz * wz;
+      double theta = Math.sqrt(theta2);
+
+      if (theta < EPS)
+      {
+         // J_l ≈ (1 - θ²/6) I + (1/2) hat(ω) + (1/6) ω ωᵀ
+         double c6 = theta2 / 6.0;
+         double s6 = 1.0 / 6.0;
+         double hx = 0.5 * wx, hy = 0.5 * wy, hz = 0.5 * wz;
+         matrixToPack.set(1.0 - c6 + s6 * wx * wx,        s6 * wx * wy - hz,       s6 * wx * wz + hy,
+                               s6 * wy * wx + hz,    1.0 - c6 + s6 * wy * wy,       s6 * wy * wz - hx,
+                               s6 * wz * wx - hy,         s6 * wz * wy + hx,  1.0 - c6 + s6 * wz * wz);
+         return;
+      }
+
+      double invTheta = 1.0 / theta;
+      double nx = wx * invTheta, ny = wy * invTheta, nz = wz * invTheta;
+
+      double sinc  = Math.sin(theta) * invTheta;   // sinθ/θ
+      double vers  = (1.0 - Math.cos(theta)) * invTheta; // (1 − cosθ)/θ
+      double omsc  = 1.0 - sinc;                         // 1 − sinθ/θ
+
+      // J_l = sinc·I + omsc·n̂n̂ᵀ + vers·hat(n̂)
+      // hat(n̂) = [[0,-nz,ny],[nz,0,-nx],[-ny,nx,0]]
+      matrixToPack.set(sinc + omsc * nx * nx,       omsc * nx * ny - vers * nz,  omsc * nx * nz + vers * ny,
+                       omsc * ny * nx + vers * nz,  sinc + omsc * ny * ny,        omsc * ny * nz - vers * nx,
+                       omsc * nz * nx - vers * ny,  omsc * nz * ny + vers * nx,  sinc + omsc * nz * nz);
+   }
+
+   /**
+    * Right Jacobian of SO(3): J_r(ω) = J_l(−ω).
+    *
+    * @param omega        the rotation vector ω. Not modified.
+    * @param matrixToPack the 3×3 matrix to pack J_r into. Modified.
+    */
+   public static void rightJacobian(Vector3DReadOnly omega, Matrix3DBasics matrixToPack)
+   {
+      double wx = omega.getX();
+      double wy = omega.getY();
+      double wz = omega.getZ();
+      double theta2 = wx * wx + wy * wy + wz * wz;
+      double theta = Math.sqrt(theta2);
+
+      if (theta < EPS)
+      {
+         // J_r = J_l(-ω): flip hat sign
+         double c6 = theta2 / 6.0;
+         double s6 = 1.0 / 6.0;
+         double hx = -0.5 * wx, hy = -0.5 * wy, hz = -0.5 * wz;
+         matrixToPack.set(1.0 - c6 + s6 * wx * wx,        s6 * wx * wy - hz,       s6 * wx * wz + hy,
+                               s6 * wy * wx + hz,    1.0 - c6 + s6 * wy * wy,       s6 * wy * wz - hx,
+                               s6 * wz * wx - hy,         s6 * wz * wy + hx,  1.0 - c6 + s6 * wz * wz);
+         return;
+      }
+
+      double invTheta = 1.0 / theta;
+      double nx = wx * invTheta, ny = wy * invTheta, nz = wz * invTheta;
+
+      double sinc = Math.sin(theta) * invTheta;
+      double vers = (1.0 - Math.cos(theta)) * invTheta;
+      double omsc = 1.0 - sinc;
+
+      // J_r = J_l(-ω): flip the hat(n̂) term sign
+      matrixToPack.set(sinc + omsc * nx * nx,       omsc * nx * ny + vers * nz,  omsc * nx * nz - vers * ny,
+                       omsc * ny * nx - vers * nz,  sinc + omsc * ny * ny,        omsc * ny * nz + vers * nx,
+                       omsc * nz * nx + vers * ny,  omsc * nz * ny - vers * nx,  sinc + omsc * nz * nz);
+   }
+
+   /**
+    * Inverse of the left Jacobian of SO(3): J_l⁻¹(ω).
+    *
+    * <p>Closed-form (θ = ‖ω‖, n̂ = ω/θ):
+    * <pre>
+    *   J_l⁻¹ = (θ/2) cot(θ/2) I  +  (1 − (θ/2) cot(θ/2)) n̂n̂ᵀ  −  (θ/2) hat(n̂)
+    * </pre>
+    * For θ &lt; EPS uses: J_l⁻¹ ≈ (1 − θ²/12) I − ½ hat(ω) + (1/12) ω ωᵀ.</p>
+    *
+    * @param omega        the rotation vector ω. Not modified.
+    * @param matrixToPack the 3×3 matrix to pack J_l⁻¹ into. Modified.
+    */
+   public static void leftJacobianInverse(Vector3DReadOnly omega, Matrix3DBasics matrixToPack)
+   {
+      double wx = omega.getX();
+      double wy = omega.getY();
+      double wz = omega.getZ();
+      double theta2 = wx * wx + wy * wy + wz * wz;
+      double theta = Math.sqrt(theta2);
+
+      if (theta < EPS)
+      {
+         // J_l⁻¹ ≈ (1 − θ²/12) I − (1/2) hat(ω) + (1/12) ω ωᵀ
+         double c12 = theta2 / 12.0;
+         double t12 = 1.0 / 12.0;
+         double hx = -0.5 * wx, hy = -0.5 * wy, hz = -0.5 * wz;
+         matrixToPack.set(1.0 - c12 + t12 * wx * wx,        t12 * wx * wy - hz,       t12 * wx * wz + hy,
+                               t12 * wy * wx + hz,    1.0 - c12 + t12 * wy * wy,       t12 * wy * wz - hx,
+                               t12 * wz * wx - hy,         t12 * wz * wy + hx,  1.0 - c12 + t12 * wz * wz);
+         return;
+      }
+
+      double invTheta = 1.0 / theta;
+      double nx = wx * invTheta, ny = wy * invTheta, nz = wz * invTheta;
+
+      double halfTheta   = 0.5 * theta;
+      double htCot       = halfTheta * (Math.cos(halfTheta) / Math.sin(halfTheta)); // (θ/2)cot(θ/2)
+      double omhtc       = 1.0 - htCot;                                             // 1 − (θ/2)cot(θ/2)
+
+      // J_l⁻¹ = htCot·I + omhtc·n̂n̂ᵀ − halfTheta·hat(n̂)
+      // −halfTheta·hat(n̂): negate the hat entries, then multiply by halfTheta
+      // hat(n̂)[0,1] = -nz  → -(−halfTheta)(−nz) = −halfTheta·(−nz) = +halfTheta·nz
+      // i.e. contribution at (0,1) = +halfTheta*nz, at (1,0) = -halfTheta*nz
+      matrixToPack.set(htCot + omhtc * nx * nx,       omhtc * nx * ny + halfTheta * nz,  omhtc * nx * nz - halfTheta * ny,
+                       omhtc * ny * nx - halfTheta * nz,  htCot + omhtc * ny * ny,        omhtc * ny * nz + halfTheta * nx,
+                       omhtc * nz * nx + halfTheta * ny,  omhtc * nz * ny - halfTheta * nx,  htCot + omhtc * nz * nz);
+   }
+
+   /**
+    * Inverse of the right Jacobian of SO(3): J_r⁻¹(ω) = J_l⁻¹(−ω).
+    *
+    * @param omega        the rotation vector ω. Not modified.
+    * @param matrixToPack the 3×3 matrix to pack J_r⁻¹ into. Modified.
+    */
+   public static void rightJacobianInverse(Vector3DReadOnly omega, Matrix3DBasics matrixToPack)
+   {
+      double wx = omega.getX();
+      double wy = omega.getY();
+      double wz = omega.getZ();
+      double theta2 = wx * wx + wy * wy + wz * wz;
+      double theta = Math.sqrt(theta2);
+
+      if (theta < EPS)
+      {
+         // J_r⁻¹ = J_l⁻¹(-ω): flip hat sign → (1 − θ²/12) I + (1/2) hat(ω) + (1/12) ω ωᵀ
+         double c12 = theta2 / 12.0;
+         double t12 = 1.0 / 12.0;
+         double hx = 0.5 * wx, hy = 0.5 * wy, hz = 0.5 * wz;
+         matrixToPack.set(1.0 - c12 + t12 * wx * wx,        t12 * wx * wy - hz,       t12 * wx * wz + hy,
+                               t12 * wy * wx + hz,    1.0 - c12 + t12 * wy * wy,       t12 * wy * wz - hx,
+                               t12 * wz * wx - hy,         t12 * wz * wy + hx,  1.0 - c12 + t12 * wz * wz);
+         return;
+      }
+
+      double invTheta = 1.0 / theta;
+      double nx = wx * invTheta, ny = wy * invTheta, nz = wz * invTheta;
+
+      double halfTheta = 0.5 * theta;
+      double htCot     = halfTheta * (Math.cos(halfTheta) / Math.sin(halfTheta));
+      double omhtc     = 1.0 - htCot;
+
+      // J_r⁻¹ = J_l⁻¹(-ω): flip the hat(n̂) sign → +halfTheta·hat(n̂)
+      matrixToPack.set(htCot + omhtc * nx * nx,       omhtc * nx * ny - halfTheta * nz,  omhtc * nx * nz + halfTheta * ny,
+                       omhtc * ny * nx + halfTheta * nz,  htCot + omhtc * ny * ny,        omhtc * ny * nz - halfTheta * nx,
+                       omhtc * nz * nx - halfTheta * ny,  omhtc * nz * ny + halfTheta * nx,  htCot + omhtc * nz * nz);
+   }
+}

--- a/src/test/java/us/ihmc/euclid/lieGroup/SE3LieGroupToolsTest.java
+++ b/src/test/java/us/ihmc/euclid/lieGroup/SE3LieGroupToolsTest.java
@@ -1,0 +1,298 @@
+package us.ihmc.euclid.lieGroup;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Random;
+
+import org.ejml.data.DMatrixRMaj;
+import org.ejml.dense.row.CommonOps_DDRM;
+import org.junit.jupiter.api.Test;
+
+import us.ihmc.euclid.matrix.RotationMatrix;
+import us.ihmc.euclid.tools.EuclidCoreRandomTools;
+import us.ihmc.euclid.tools.EuclidCoreTestTools;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.tuple3D.Vector3D;
+
+public class SE3LieGroupToolsTest
+{
+   private static final double EPSILON = 1.0e-10;
+   private static final int ITERATIONS = 1000;
+
+   // -----------------------------------------------------------------------
+   // hat / vee
+   // -----------------------------------------------------------------------
+
+   @Test
+   public void testHatStructure()
+   {
+      Random random = new Random(1234L);
+      DMatrixRMaj hat = new DMatrixRMaj(4, 4);
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         double[] xi = randomXi(random);
+         SE3LieGroupTools.hat(xi, hat);
+
+         double rhoX = xi[0], rhoY = xi[1], rhoZ = xi[2];
+         double phiX = xi[3], phiY = xi[4], phiZ = xi[5];
+
+         // Last row must be zero
+         for (int c = 0; c < 4; c++)
+            assertEquals(0.0, hat.unsafe_get(3, c), EPSILON, "hat[3," + c + "]");
+
+         // Diagonal of hat(phi) block is zero
+         assertEquals(0.0, hat.unsafe_get(0, 0), EPSILON);
+         assertEquals(0.0, hat.unsafe_get(1, 1), EPSILON);
+         assertEquals(0.0, hat.unsafe_get(2, 2), EPSILON);
+
+         // Translation column
+         assertEquals(rhoX, hat.unsafe_get(0, 3), EPSILON);
+         assertEquals(rhoY, hat.unsafe_get(1, 3), EPSILON);
+         assertEquals(rhoZ, hat.unsafe_get(2, 3), EPSILON);
+
+         // hat(phi) off-diagonals
+         assertEquals(-phiZ, hat.unsafe_get(0, 1), EPSILON);
+         assertEquals( phiY, hat.unsafe_get(0, 2), EPSILON);
+         assertEquals( phiZ, hat.unsafe_get(1, 0), EPSILON);
+         assertEquals(-phiX, hat.unsafe_get(1, 2), EPSILON);
+         assertEquals(-phiY, hat.unsafe_get(2, 0), EPSILON);
+         assertEquals( phiX, hat.unsafe_get(2, 1), EPSILON);
+      }
+   }
+
+   @Test
+   public void testHatVeeRoundTrip()
+   {
+      Random random = new Random(5678L);
+      DMatrixRMaj hat = new DMatrixRMaj(4, 4);
+      double[] xiRecovered = new double[6];
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         double[] xi = randomXi(random);
+         SE3LieGroupTools.hat(xi, hat);
+         SE3LieGroupTools.vee(hat, xiRecovered);
+
+         for (int k = 0; k < 6; k++)
+            assertEquals(xi[k], xiRecovered[k], EPSILON, "xi[" + k + "]");
+      }
+   }
+
+   // -----------------------------------------------------------------------
+   // exp / log round-trips
+   // -----------------------------------------------------------------------
+
+   @Test
+   public void testExpLogRoundTrip()
+   {
+      Random random = new Random(111L);
+      RigidBodyTransform T = new RigidBodyTransform();
+      double[] xiRecovered = new double[6];
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         double[] xi = randomSmallXi(random);
+         SE3LieGroupTools.exp(xi, T);
+         SE3LieGroupTools.log(T, xiRecovered);
+
+         for (int k = 0; k < 6; k++)
+            assertEquals(xi[k], xiRecovered[k], EPSILON, "xi[" + k + "]");
+      }
+   }
+
+   @Test
+   public void testLogExpRoundTrip()
+   {
+      Random random = new Random(222L);
+      RigidBodyTransform Tback = new RigidBodyTransform();
+      double[] xi = new double[6];
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         RigidBodyTransform T = EuclidCoreRandomTools.nextRigidBodyTransform(random);
+         SE3LieGroupTools.log(T, xi);
+         SE3LieGroupTools.exp(xi, Tback);
+
+         EuclidCoreTestTools.assertMatrix3DEquals(T.getRotation(), Tback.getRotation(), EPSILON);
+         assertEquals(T.getTranslationX(), Tback.getTranslationX(), EPSILON);
+         assertEquals(T.getTranslationY(), Tback.getTranslationY(), EPSILON);
+         assertEquals(T.getTranslationZ(), Tback.getTranslationZ(), EPSILON);
+      }
+   }
+
+   @Test
+   public void testExpPureRotation()
+   {
+      // exp([0; phi]) rotation must match SO(3) exp; translation must be zero
+      Random random = new Random(333L);
+      RigidBodyTransform T = new RigidBodyTransform();
+      RotationMatrix Rexpected = new RotationMatrix();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D phi = EuclidCoreRandomTools.nextRotationVector(random);
+         double[] xi = {0.0, 0.0, 0.0, phi.getX(), phi.getY(), phi.getZ()};
+         SE3LieGroupTools.exp(xi, T);
+
+         SO3LieGroupTools.exp(phi, Rexpected);
+         EuclidCoreTestTools.assertMatrix3DEquals(Rexpected, T.getRotation(), EPSILON);
+         assertEquals(0.0, T.getTranslationX(), EPSILON);
+         assertEquals(0.0, T.getTranslationY(), EPSILON);
+         assertEquals(0.0, T.getTranslationZ(), EPSILON);
+      }
+   }
+
+   @Test
+   public void testExpPureTranslation()
+   {
+      // exp([rho; 0]) = (I, rho)
+      Random random = new Random(444L);
+      RigidBodyTransform T = new RigidBodyTransform();
+      RotationMatrix identity = new RotationMatrix();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D rho = EuclidCoreRandomTools.nextVector3D(random);
+         double[] xi = {rho.getX(), rho.getY(), rho.getZ(), 0.0, 0.0, 0.0};
+         SE3LieGroupTools.exp(xi, T);
+
+         EuclidCoreTestTools.assertMatrix3DEquals(identity, T.getRotation(), EPSILON);
+         assertEquals(rho.getX(), T.getTranslationX(), EPSILON);
+         assertEquals(rho.getY(), T.getTranslationY(), EPSILON);
+         assertEquals(rho.getZ(), T.getTranslationZ(), EPSILON);
+      }
+   }
+
+   @Test
+   public void testExpIdentity()
+   {
+      double[] zero = new double[6];
+      RigidBodyTransform T = new RigidBodyTransform();
+      SE3LieGroupTools.exp(zero, T);
+
+      RotationMatrix identity = new RotationMatrix();
+      EuclidCoreTestTools.assertMatrix3DEquals(identity, T.getRotation(), EPSILON);
+      assertEquals(0.0, T.getTranslationX(), EPSILON);
+      assertEquals(0.0, T.getTranslationY(), EPSILON);
+      assertEquals(0.0, T.getTranslationZ(), EPSILON);
+   }
+
+   // -----------------------------------------------------------------------
+   // Adjoint
+   // -----------------------------------------------------------------------
+
+   @Test
+   public void testAdjointGroupHomomorphism()
+   {
+      // Ad_{T1 * T2} = Ad_{T1} * Ad_{T2}
+      Random random = new Random(555L);
+      DMatrixRMaj adT1 = new DMatrixRMaj(6, 6);
+      DMatrixRMaj adT2 = new DMatrixRMaj(6, 6);
+      DMatrixRMaj adT1T2 = new DMatrixRMaj(6, 6);
+      DMatrixRMaj product = new DMatrixRMaj(6, 6);
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         RigidBodyTransform T1 = EuclidCoreRandomTools.nextRigidBodyTransform(random);
+         RigidBodyTransform T2 = EuclidCoreRandomTools.nextRigidBodyTransform(random);
+         RigidBodyTransform T1T2 = new RigidBodyTransform(T1);
+         T1T2.multiply(T2);
+
+         SE3LieGroupTools.adjoint(T1, adT1);
+         SE3LieGroupTools.adjoint(T2, adT2);
+         SE3LieGroupTools.adjoint(T1T2, adT1T2);
+
+         CommonOps_DDRM.mult(adT1, adT2, product);
+
+         assertDMatrixEquals(adT1T2, product, 1.0e-8);
+      }
+   }
+
+   @Test
+   public void testAdjointIdentity()
+   {
+      RigidBodyTransform identity = new RigidBodyTransform();
+      DMatrixRMaj ad = new DMatrixRMaj(6, 6);
+      SE3LieGroupTools.adjoint(identity, ad);
+
+      for (int r = 0; r < 6; r++)
+         for (int c = 0; c < 6; c++)
+            assertEquals(r == c ? 1.0 : 0.0, ad.unsafe_get(r, c), EPSILON, "Ad_I[" + r + "," + c + "]");
+   }
+
+   @Test
+   public void testSmallAdjointBracket()
+   {
+      // ad_xi1 * xi2 should equal the se(3) Lie bracket [xi1, xi2]:
+      //   rho part: phi1 x rho2 + rho1 x phi2
+      //   phi part: phi1 x phi2
+      Random random = new Random(666L);
+      DMatrixRMaj adXi1 = new DMatrixRMaj(6, 6);
+      DMatrixRMaj xi2Mat = new DMatrixRMaj(6, 1);
+      DMatrixRMaj bracket = new DMatrixRMaj(6, 1);
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         double[] xi1 = randomXi(random);
+         double[] xi2 = randomXi(random);
+
+         SE3LieGroupTools.smallAdjoint(xi1, adXi1);
+         for (int k = 0; k < 6; k++) xi2Mat.unsafe_set(k, 0, xi2[k]);
+         CommonOps_DDRM.mult(adXi1, xi2Mat, bracket);
+
+         Vector3D rho1 = new Vector3D(xi1[0], xi1[1], xi1[2]);
+         Vector3D phi1 = new Vector3D(xi1[3], xi1[4], xi1[5]);
+         Vector3D rho2 = new Vector3D(xi2[0], xi2[1], xi2[2]);
+         Vector3D phi2 = new Vector3D(xi2[3], xi2[4], xi2[5]);
+
+         Vector3D expectedRho = new Vector3D();
+         Vector3D tmp = new Vector3D();
+         expectedRho.cross(phi1, rho2);
+         tmp.cross(rho1, phi2);
+         expectedRho.add(tmp);
+
+         Vector3D expectedPhi = new Vector3D();
+         expectedPhi.cross(phi1, phi2);
+
+         assertEquals(expectedRho.getX(), bracket.unsafe_get(0, 0), EPSILON);
+         assertEquals(expectedRho.getY(), bracket.unsafe_get(1, 0), EPSILON);
+         assertEquals(expectedRho.getZ(), bracket.unsafe_get(2, 0), EPSILON);
+         assertEquals(expectedPhi.getX(), bracket.unsafe_get(3, 0), EPSILON);
+         assertEquals(expectedPhi.getY(), bracket.unsafe_get(4, 0), EPSILON);
+         assertEquals(expectedPhi.getZ(), bracket.unsafe_get(5, 0), EPSILON);
+      }
+   }
+
+   // -----------------------------------------------------------------------
+   // helpers
+   // -----------------------------------------------------------------------
+
+   private static double[] randomXi(Random random)
+   {
+      double[] xi = new double[6];
+      for (int k = 0; k < 3; k++) xi[k] = EuclidCoreRandomTools.nextDouble(random, 5.0);
+      Vector3D phi = EuclidCoreRandomTools.nextRotationVector(random);
+      xi[3] = phi.getX(); xi[4] = phi.getY(); xi[5] = phi.getZ();
+      return xi;
+   }
+
+   private static double[] randomSmallXi(Random random)
+   {
+      double[] xi = new double[6];
+      for (int k = 0; k < 3; k++) xi[k] = EuclidCoreRandomTools.nextDouble(random, 5.0);
+      Vector3D phi = EuclidCoreRandomTools.nextRotationVector(random, Math.PI - 1e-3);
+      xi[3] = phi.getX(); xi[4] = phi.getY(); xi[5] = phi.getZ();
+      return xi;
+   }
+
+   private static void assertDMatrixEquals(DMatrixRMaj expected, DMatrixRMaj actual, double epsilon)
+   {
+      assertEquals(expected.numRows, actual.numRows);
+      assertEquals(expected.numCols, actual.numCols);
+      for (int r = 0; r < expected.numRows; r++)
+         for (int c = 0; c < expected.numCols; c++)
+            assertEquals(expected.unsafe_get(r, c), actual.unsafe_get(r, c), epsilon,
+                         "Matrix[" + r + "," + c + "]");
+   }
+}

--- a/src/test/java/us/ihmc/euclid/lieGroup/SE3LieGroupToolsTest.java
+++ b/src/test/java/us/ihmc/euclid/lieGroup/SE3LieGroupToolsTest.java
@@ -1,13 +1,16 @@
 package us.ihmc.euclid.lieGroup;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.lang.management.ManagementFactory;
 import java.util.Random;
 
 import org.ejml.data.DMatrixRMaj;
 import org.ejml.dense.row.CommonOps_DDRM;
 import org.junit.jupiter.api.Test;
 
+import us.ihmc.euclid.matrix.Matrix3D;
 import us.ihmc.euclid.matrix.RotationMatrix;
 import us.ihmc.euclid.tools.EuclidCoreRandomTools;
 import us.ihmc.euclid.tools.EuclidCoreTestTools;
@@ -18,6 +21,15 @@ public class SE3LieGroupToolsTest
 {
    private static final double EPSILON = 1.0e-10;
    private static final int ITERATIONS = 1000;
+
+   /** Iterations run before measuring, so JIT compilation and one-off class init are already paid. */
+   private static final int WARMUP_ITERATIONS = 50_000;
+   /** Measurement rounds; the minimum is taken to filter an occasional deopt/recompile blip. */
+   private static final int ALLOCATION_ROUNDS = 5;
+   /** Iterations per measurement round. */
+   private static final int ALLOCATION_ITERATIONS = 20_000;
+   /** Noise budget for a round. Expected to be 0; the allocating overloads would burn megabytes. */
+   private static final long ALLOCATION_TOLERANCE_BYTES = 4096L;
 
    // -----------------------------------------------------------------------
    // hat / vee
@@ -262,6 +274,96 @@ public class SE3LieGroupToolsTest
          assertEquals(expectedRho.getY(), bracket.unsafe_get(4, 0), EPSILON);
          assertEquals(expectedRho.getZ(), bracket.unsafe_get(5, 0), EPSILON);
       }
+   }
+
+   // -----------------------------------------------------------------------
+   // allocation
+   // -----------------------------------------------------------------------
+
+   /**
+    * Guards the per-tick contract: the allocation-free overloads of {@code exp}/{@code log}/
+    * {@code adjoint} — the ones taking the intermediates as parameters — must not allocate.
+    *
+    * <p>Allocation is measured with {@code ThreadMXBean.getThreadAllocatedBytes} on this thread,
+    * which counts bytes on the TLAB rather than sampling the heap, so it sees allocations even when
+    * no GC runs. The loop is warmed first and the minimum across several rounds is taken.</p>
+    *
+    * <p>The signal is enormous relative to the tolerance: the convenience overloads allocate on the
+    * order of 200 B per call, so a regression on any of the three shows up as several MB per round
+    * against a 4 KB budget. The budget exists for measurement noise only — the expected value is
+    * exactly 0.</p>
+    */
+   @Test
+   public void testAllocationFree()
+   {
+      java.lang.management.ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+      assumeTrue(bean instanceof com.sun.management.ThreadMXBean, "allocation counters unavailable on this JVM");
+      com.sun.management.ThreadMXBean threadBean = (com.sun.management.ThreadMXBean) bean;
+      assumeTrue(threadBean.isThreadAllocatedMemorySupported(), "thread allocation measurement unsupported");
+      threadBean.setThreadAllocatedMemoryEnabled(true);
+      assumeTrue(threadBean.isThreadAllocatedMemoryEnabled(), "thread allocation measurement disabled");
+
+      long threadId = Thread.currentThread().getId();
+
+      // Everything the loop touches is allocated up front — the harness has to be silent too.
+      RigidBodyTransform transform = new RigidBodyTransform();
+      DMatrixRMaj adjoint = new DMatrixRMaj(6, 6);
+      double[] xiIn = new double[6];
+      double[] xiOut = new double[6];
+
+      Vector3D phi = new Vector3D();
+      Matrix3D jacobian = new Matrix3D();
+      RotationMatrix rotation = new RotationMatrix();
+
+      double sink = 0.0;
+
+      for (int i = 0; i < WARMUP_ITERATIONS; i++)
+         sink += driveOnce(i, xiIn, xiOut, transform, adjoint, phi, jacobian, rotation);
+
+      long fewestBytes = Long.MAX_VALUE;
+      for (int round = 0; round < ALLOCATION_ROUNDS; round++)
+      {
+         long before = threadBean.getThreadAllocatedBytes(threadId);
+         for (int i = 0; i < ALLOCATION_ITERATIONS; i++)
+            sink += driveOnce(i, xiIn, xiOut, transform, adjoint, phi, jacobian, rotation);
+         long after = threadBean.getThreadAllocatedBytes(threadId);
+
+         fewestBytes = Math.min(fewestBytes, after - before);
+      }
+
+      // Keep the work observable so the loop cannot be optimized away wholesale.
+      assertFalse(Double.isNaN(sink), "loop result went NaN");
+
+      assertTrue(fewestBytes <= ALLOCATION_TOLERANCE_BYTES,
+                 "exp/log/adjoint allocation-free overloads allocated " + fewestBytes + " bytes over " + ALLOCATION_ITERATIONS
+                       + " iterations (tolerance " + ALLOCATION_TOLERANCE_BYTES + " B) — a per-tick allocation has regressed");
+   }
+
+   /** One exp → log → adjoint cycle through the allocation-free overloads. Must not allocate. */
+   private static double driveOnce(int i,
+                                   double[] xiIn,
+                                   double[] xiOut,
+                                   RigidBodyTransform transform,
+                                   DMatrixRMaj adjoint,
+                                   Vector3D phi,
+                                   Matrix3D jacobian,
+                                   RotationMatrix rotation)
+   {
+      // Vary the input without allocating, keeping |φ| well inside (0, π) so the generic (non-small-angle)
+      // branch of the Jacobians is the one under test.
+      double t = 1.0e-3 * (i % 1000);
+      xiIn[0] = 0.3 + t;
+      xiIn[1] = -0.2 + t;
+      xiIn[2] = 0.5 - t;
+      xiIn[3] = 1.0 + t;
+      xiIn[4] = -2.0 + t;
+      xiIn[5] = 0.7 + t;
+
+      SE3LieGroupTools.exp(xiIn, transform, phi, jacobian);
+      SE3LieGroupTools.log(transform, xiOut, phi, jacobian);
+      SE3LieGroupTools.adjoint(transform, adjoint, rotation);
+
+      return xiOut[0] + xiOut[5] + adjoint.unsafe_get(3, 0);
    }
 
    // -----------------------------------------------------------------------

--- a/src/test/java/us/ihmc/euclid/lieGroup/SE3LieGroupToolsTest.java
+++ b/src/test/java/us/ihmc/euclid/lieGroup/SE3LieGroupToolsTest.java
@@ -34,8 +34,8 @@ public class SE3LieGroupToolsTest
          double[] xi = randomXi(random);
          SE3LieGroupTools.hat(xi, hat);
 
-         double rhoX = xi[0], rhoY = xi[1], rhoZ = xi[2];
-         double phiX = xi[3], phiY = xi[4], phiZ = xi[5];
+         double phiX = xi[0], phiY = xi[1], phiZ = xi[2];
+         double rhoX = xi[3], rhoY = xi[4], rhoZ = xi[5];
 
          // Last row must be zero
          for (int c = 0; c < 4; c++)
@@ -132,7 +132,7 @@ public class SE3LieGroupToolsTest
       for (int i = 0; i < ITERATIONS; i++)
       {
          Vector3D phi = EuclidCoreRandomTools.nextRotationVector(random);
-         double[] xi = {0.0, 0.0, 0.0, phi.getX(), phi.getY(), phi.getZ()};
+         double[] xi = {phi.getX(), phi.getY(), phi.getZ(), 0.0, 0.0, 0.0};
          SE3LieGroupTools.exp(xi, T);
 
          SO3LieGroupTools.exp(phi, Rexpected);
@@ -154,7 +154,7 @@ public class SE3LieGroupToolsTest
       for (int i = 0; i < ITERATIONS; i++)
       {
          Vector3D rho = EuclidCoreRandomTools.nextVector3D(random);
-         double[] xi = {rho.getX(), rho.getY(), rho.getZ(), 0.0, 0.0, 0.0};
+         double[] xi = {0.0, 0.0, 0.0, rho.getX(), rho.getY(), rho.getZ()};
          SE3LieGroupTools.exp(xi, T);
 
          EuclidCoreTestTools.assertMatrix3DEquals(identity, T.getRotation(), EPSILON);
@@ -225,8 +225,8 @@ public class SE3LieGroupToolsTest
    public void testSmallAdjointBracket()
    {
       // ad_xi1 * xi2 should equal the se(3) Lie bracket [xi1, xi2]:
-      //   rho part: phi1 x rho2 + rho1 x phi2
       //   phi part: phi1 x phi2
+      //   rho part: phi1 x rho2 + rho1 x phi2
       Random random = new Random(666L);
       DMatrixRMaj adXi1 = new DMatrixRMaj(6, 6);
       DMatrixRMaj xi2Mat = new DMatrixRMaj(6, 1);
@@ -241,10 +241,10 @@ public class SE3LieGroupToolsTest
          for (int k = 0; k < 6; k++) xi2Mat.unsafe_set(k, 0, xi2[k]);
          CommonOps_DDRM.mult(adXi1, xi2Mat, bracket);
 
-         Vector3D rho1 = new Vector3D(xi1[0], xi1[1], xi1[2]);
-         Vector3D phi1 = new Vector3D(xi1[3], xi1[4], xi1[5]);
-         Vector3D rho2 = new Vector3D(xi2[0], xi2[1], xi2[2]);
-         Vector3D phi2 = new Vector3D(xi2[3], xi2[4], xi2[5]);
+         Vector3D phi1 = new Vector3D(xi1[0], xi1[1], xi1[2]);
+         Vector3D rho1 = new Vector3D(xi1[3], xi1[4], xi1[5]);
+         Vector3D phi2 = new Vector3D(xi2[0], xi2[1], xi2[2]);
+         Vector3D rho2 = new Vector3D(xi2[3], xi2[4], xi2[5]);
 
          Vector3D expectedRho = new Vector3D();
          Vector3D tmp = new Vector3D();
@@ -255,12 +255,12 @@ public class SE3LieGroupToolsTest
          Vector3D expectedPhi = new Vector3D();
          expectedPhi.cross(phi1, phi2);
 
-         assertEquals(expectedRho.getX(), bracket.unsafe_get(0, 0), EPSILON);
-         assertEquals(expectedRho.getY(), bracket.unsafe_get(1, 0), EPSILON);
-         assertEquals(expectedRho.getZ(), bracket.unsafe_get(2, 0), EPSILON);
-         assertEquals(expectedPhi.getX(), bracket.unsafe_get(3, 0), EPSILON);
-         assertEquals(expectedPhi.getY(), bracket.unsafe_get(4, 0), EPSILON);
-         assertEquals(expectedPhi.getZ(), bracket.unsafe_get(5, 0), EPSILON);
+         assertEquals(expectedPhi.getX(), bracket.unsafe_get(0, 0), EPSILON);
+         assertEquals(expectedPhi.getY(), bracket.unsafe_get(1, 0), EPSILON);
+         assertEquals(expectedPhi.getZ(), bracket.unsafe_get(2, 0), EPSILON);
+         assertEquals(expectedRho.getX(), bracket.unsafe_get(3, 0), EPSILON);
+         assertEquals(expectedRho.getY(), bracket.unsafe_get(4, 0), EPSILON);
+         assertEquals(expectedRho.getZ(), bracket.unsafe_get(5, 0), EPSILON);
       }
    }
 
@@ -271,18 +271,18 @@ public class SE3LieGroupToolsTest
    private static double[] randomXi(Random random)
    {
       double[] xi = new double[6];
-      for (int k = 0; k < 3; k++) xi[k] = EuclidCoreRandomTools.nextDouble(random, 5.0);
       Vector3D phi = EuclidCoreRandomTools.nextRotationVector(random);
-      xi[3] = phi.getX(); xi[4] = phi.getY(); xi[5] = phi.getZ();
+      xi[0] = phi.getX(); xi[1] = phi.getY(); xi[2] = phi.getZ();
+      for (int k = 3; k < 6; k++) xi[k] = EuclidCoreRandomTools.nextDouble(random, 5.0);
       return xi;
    }
 
    private static double[] randomSmallXi(Random random)
    {
       double[] xi = new double[6];
-      for (int k = 0; k < 3; k++) xi[k] = EuclidCoreRandomTools.nextDouble(random, 5.0);
       Vector3D phi = EuclidCoreRandomTools.nextRotationVector(random, Math.PI - 1e-3);
-      xi[3] = phi.getX(); xi[4] = phi.getY(); xi[5] = phi.getZ();
+      xi[0] = phi.getX(); xi[1] = phi.getY(); xi[2] = phi.getZ();
+      for (int k = 3; k < 6; k++) xi[k] = EuclidCoreRandomTools.nextDouble(random, 5.0);
       return xi;
    }
 

--- a/src/test/java/us/ihmc/euclid/lieGroup/SO3LieGroupToolsTest.java
+++ b/src/test/java/us/ihmc/euclid/lieGroup/SO3LieGroupToolsTest.java
@@ -292,6 +292,84 @@ public class SO3LieGroupToolsTest
       }
    }
 
+   @Test
+   public void testGamma2AtZero()
+   {
+      // Γ₂(0) = Σ φ̂ⁿ/(n+2)! evaluated at 0 = I/2! = ½I
+      Matrix3D gamma2 = new Matrix3D();
+      SO3LieGroupTools.gamma2(new Vector3D(0.0, 0.0, 0.0), gamma2);
+
+     Matrix3D halfIdentity = new Matrix3D();
+     halfIdentity.setIdentity();
+     halfIdentity.scale(0.5);
+
+     EuclidCoreTestTools.assertMatrix3DEquals(halfIdentity, gamma2, EPSILON);
+   }
+
+   @Test
+   public void testGamma2RecurrenceWithLeftJacobian()
+   {
+      // Recurrence Γ₁(φ) = I + hat(φ)·Γ₂(φ), with Γ₁ = leftJacobian.
+      Random random = new Random(2024L);
+      Matrix3D gamma2 = new Matrix3D();
+      Matrix3D hatPhi = new Matrix3D();
+      Matrix3D Jl = new Matrix3D();
+      Matrix3D reconstructed = new Matrix3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D phi = EuclidCoreRandomTools.nextRotationVector(random);
+         SO3LieGroupTools.gamma2(phi,gamma2);
+         SO3LieGroupTools.hat(phi, hatPhi);
+         SO3LieGroupTools.leftJacobian(phi, Jl);
+
+
+         // reconstructed = I + hatPhi * gamma2
+         for (int r = 0; r < 3; r++)
+         {
+            for (int c = 0; c < 3; c++)
+            {
+               double sum = (r == c) ? 1.0 : 0.0;
+               for (int k = 0; k < 3; k++)
+                  sum += hatPhi.getElement(r,k) * gamma2.getElement(k,c);
+               reconstructed.setElement(r,c,sum);
+            }
+         }
+         EuclidCoreTestTools.assertMatrix3DEquals(Jl, reconstructed, 1.0e-9);
+      }
+   }
+
+   @Test
+   public void testGamma2SmallAngleRecurrence()
+   {
+      // Same recurrence but with the small angle assumption, to try out the Taylor series and make sure that it works
+      Random random = new Random(4096L);
+      Matrix3D gamma2 = new Matrix3D();
+      Matrix3D hatPhi = new Matrix3D();
+      Matrix3D Jl = new Matrix3D();
+      Matrix3D reconstructed = new Matrix3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D phi = EuclidCoreRandomTools.nextRotationVector(random, 1.0e-8);
+         SO3LieGroupTools.gamma2(phi,gamma2);
+         SO3LieGroupTools.hat(phi, hatPhi);
+         SO3LieGroupTools.leftJacobian(phi, Jl);
+
+         for (int r = 0; r < 3; r++)
+         {
+            for (int c = 0; c < 3; c++)
+            {
+               double sum = (r == c) ? 1.0 : 0.0;
+               for (int k = 0; k < 3; k++)
+                  sum += hatPhi.getElement(r,k) * gamma2.getElement(k,c);
+               reconstructed.setElement(r,c,sum);
+            }
+         }
+         EuclidCoreTestTools.assertMatrix3DEquals(Jl, reconstructed, 1.0e-12);
+      }
+   }
+
    // -----------------------------------------------------------------------
    // helpers
    // -----------------------------------------------------------------------

--- a/src/test/java/us/ihmc/euclid/lieGroup/SO3LieGroupToolsTest.java
+++ b/src/test/java/us/ihmc/euclid/lieGroup/SO3LieGroupToolsTest.java
@@ -1,0 +1,313 @@
+package us.ihmc.euclid.lieGroup;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import us.ihmc.euclid.matrix.Matrix3D;
+import us.ihmc.euclid.matrix.RotationMatrix;
+import us.ihmc.euclid.tools.EuclidCoreRandomTools;
+import us.ihmc.euclid.tools.EuclidCoreTestTools;
+import us.ihmc.euclid.tuple3D.Vector3D;
+import us.ihmc.euclid.tuple4D.Quaternion;
+
+public class SO3LieGroupToolsTest
+{
+   private static final double EPSILON = 1.0e-10;
+   private static final int ITERATIONS = 1000;
+
+   // -----------------------------------------------------------------------
+   // hat / vee
+   // -----------------------------------------------------------------------
+
+   @Test
+   public void testHatSkewSymmetry()
+   {
+      Random random = new Random(1234L);
+      Matrix3D mat = new Matrix3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D omega = EuclidCoreRandomTools.nextVector3D(random);
+         SO3LieGroupTools.hat(omega, mat);
+
+         assertEquals(0.0, mat.getM00(), EPSILON);
+         assertEquals(0.0, mat.getM11(), EPSILON);
+         assertEquals(0.0, mat.getM22(), EPSILON);
+         assertEquals(mat.getM01(), -mat.getM10(), EPSILON);
+         assertEquals(mat.getM02(), -mat.getM20(), EPSILON);
+         assertEquals(mat.getM12(), -mat.getM21(), EPSILON);
+      }
+   }
+
+   @Test
+   public void testHatCrossProduct()
+   {
+      Random random = new Random(5678L);
+      Matrix3D mat = new Matrix3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D omega = EuclidCoreRandomTools.nextVector3D(random);
+         Vector3D v = EuclidCoreRandomTools.nextVector3D(random);
+         SO3LieGroupTools.hat(omega, mat);
+
+         Vector3D expected = new Vector3D();
+         expected.cross(omega, v);
+
+         double rx = mat.getM00() * v.getX() + mat.getM01() * v.getY() + mat.getM02() * v.getZ();
+         double ry = mat.getM10() * v.getX() + mat.getM11() * v.getY() + mat.getM12() * v.getZ();
+         double rz = mat.getM20() * v.getX() + mat.getM21() * v.getY() + mat.getM22() * v.getZ();
+
+         assertEquals(expected.getX(), rx, EPSILON);
+         assertEquals(expected.getY(), ry, EPSILON);
+         assertEquals(expected.getZ(), rz, EPSILON);
+      }
+   }
+
+   @Test
+   public void testHatVeeRoundTrip()
+   {
+      Random random = new Random(9012L);
+      Matrix3D mat = new Matrix3D();
+      Vector3D recovered = new Vector3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D omega = EuclidCoreRandomTools.nextVector3D(random);
+         SO3LieGroupTools.hat(omega, mat);
+         SO3LieGroupTools.vee(mat, recovered);
+
+         assertEquals(omega.getX(), recovered.getX(), EPSILON);
+         assertEquals(omega.getY(), recovered.getY(), EPSILON);
+         assertEquals(omega.getZ(), recovered.getZ(), EPSILON);
+      }
+   }
+
+   // -----------------------------------------------------------------------
+   // exp / log round-trips
+   // -----------------------------------------------------------------------
+
+   @Test
+   public void testExpLogRoundTrip_vectorToVector()
+   {
+      Random random = new Random(111L);
+      Quaternion q = new Quaternion();
+      Vector3D recovered = new Vector3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D omega = EuclidCoreRandomTools.nextRotationVector(random);
+         SO3LieGroupTools.exp(omega, q);
+         SO3LieGroupTools.log(q, recovered);
+
+         assertEquals(omega.getX(), recovered.getX(), EPSILON);
+         assertEquals(omega.getY(), recovered.getY(), EPSILON);
+         assertEquals(omega.getZ(), recovered.getZ(), EPSILON);
+      }
+   }
+
+   @Test
+   public void testExpLogRoundTrip_rotationToRotation()
+   {
+      Random random = new Random(222L);
+      Vector3D omega = new Vector3D();
+      RotationMatrix Rback = new RotationMatrix();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         RotationMatrix R = EuclidCoreRandomTools.nextRotationMatrix(random);
+         SO3LieGroupTools.log(R, omega);
+         SO3LieGroupTools.exp(omega, Rback);
+
+         EuclidCoreTestTools.assertMatrix3DEquals(R, Rback, EPSILON);
+      }
+   }
+
+   @Test
+   public void testExpIdentity()
+   {
+      Vector3D zero = new Vector3D(0.0, 0.0, 0.0);
+      Quaternion q = new Quaternion();
+      SO3LieGroupTools.exp(zero, q);
+
+      assertEquals(0.0, q.getX(), EPSILON);
+      assertEquals(0.0, q.getY(), EPSILON);
+      assertEquals(0.0, q.getZ(), EPSILON);
+      assertEquals(1.0, q.getS(), EPSILON);
+   }
+
+   // -----------------------------------------------------------------------
+   // adjoint / smallAdjoint
+   // -----------------------------------------------------------------------
+
+   @Test
+   public void testAdjointEqualsRotationMatrix()
+   {
+      Random random = new Random(333L);
+      Matrix3D ad = new Matrix3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         RotationMatrix R = EuclidCoreRandomTools.nextRotationMatrix(random);
+         SO3LieGroupTools.adjoint(R, ad);
+         EuclidCoreTestTools.assertMatrix3DEquals(R, ad, EPSILON);
+      }
+   }
+
+   @Test
+   public void testSmallAdjointEqualsHat()
+   {
+      Random random = new Random(444L);
+      Matrix3D adSmall = new Matrix3D();
+      Matrix3D hatM = new Matrix3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D omega = EuclidCoreRandomTools.nextVector3D(random);
+         SO3LieGroupTools.smallAdjoint(omega, adSmall);
+         SO3LieGroupTools.hat(omega, hatM);
+         EuclidCoreTestTools.assertMatrix3DEquals(hatM, adSmall, EPSILON);
+      }
+   }
+
+   // -----------------------------------------------------------------------
+   // Jacobians
+   // -----------------------------------------------------------------------
+
+   @Test
+   public void testJacobianNearZeroFirstOrder()
+   {
+      // For small ω: J_l ≈ I + ½ hat(ω)  (first-order)
+      Random random = new Random(555L);
+      Matrix3D Jl = new Matrix3D();
+      Matrix3D hatM = new Matrix3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D omega = EuclidCoreRandomTools.nextVector3D(random, 1e-5);
+         SO3LieGroupTools.leftJacobian(omega, Jl);
+         SO3LieGroupTools.hat(omega, hatM);
+
+         double tol = 1e-9; // second-order terms are O(θ²) ≈ O(1e-10)
+         assertEquals(1.0, Jl.getM00(), tol);
+         assertEquals(1.0, Jl.getM11(), tol);
+         assertEquals(1.0, Jl.getM22(), tol);
+         assertEquals(0.5 * hatM.getM01(), Jl.getM01(), tol);
+         assertEquals(0.5 * hatM.getM10(), Jl.getM10(), tol);
+      }
+   }
+
+   @Test
+   public void testJacobiansLeftRightRelation()
+   {
+      // J_r(ω) = J_l(-ω)
+      Random random = new Random(666L);
+      Matrix3D Jl = new Matrix3D();
+      Matrix3D Jr = new Matrix3D();
+      Matrix3D JlNeg = new Matrix3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D omega = EuclidCoreRandomTools.nextRotationVector(random);
+         SO3LieGroupTools.leftJacobian(omega, Jl);
+         SO3LieGroupTools.rightJacobian(omega, Jr);
+
+         Vector3D omegaNeg = new Vector3D(-omega.getX(), -omega.getY(), -omega.getZ());
+         SO3LieGroupTools.leftJacobian(omegaNeg, JlNeg);
+
+         EuclidCoreTestTools.assertMatrix3DEquals(JlNeg, Jr, EPSILON);
+      }
+   }
+
+   @Test
+   public void testJacobianInverseRelations()
+   {
+      // J_l⁻¹ * J_l = I   and   J_r⁻¹ * J_r = I
+      Random random = new Random(777L);
+      Matrix3D Jl = new Matrix3D();
+      Matrix3D JlInv = new Matrix3D();
+      Matrix3D Jr = new Matrix3D();
+      Matrix3D JrInv = new Matrix3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D omega = EuclidCoreRandomTools.nextRotationVector(random);
+
+         SO3LieGroupTools.leftJacobian(omega, Jl);
+         SO3LieGroupTools.leftJacobianInverse(omega, JlInv);
+         assertMatrix3DProductIsIdentity(JlInv, Jl, 1.0e-9);
+
+         SO3LieGroupTools.rightJacobian(omega, Jr);
+         SO3LieGroupTools.rightJacobianInverse(omega, JrInv);
+         assertMatrix3DProductIsIdentity(JrInv, Jr, 1.0e-9);
+      }
+   }
+
+   @Test
+   public void testRightJacobianInverseRelation()
+   {
+      // J_r⁻¹(ω) = J_l⁻¹(-ω)
+      Random random = new Random(888L);
+      Matrix3D JrInv = new Matrix3D();
+      Matrix3D JlInvNeg = new Matrix3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D omega = EuclidCoreRandomTools.nextRotationVector(random);
+         SO3LieGroupTools.rightJacobianInverse(omega, JrInv);
+
+         Vector3D omegaNeg = new Vector3D(-omega.getX(), -omega.getY(), -omega.getZ());
+         SO3LieGroupTools.leftJacobianInverse(omegaNeg, JlInvNeg);
+
+         EuclidCoreTestTools.assertMatrix3DEquals(JlInvNeg, JrInv, EPSILON);
+      }
+   }
+
+   @Test
+   public void testJacobianJlTransposeEqualsJr()
+   {
+      // For SO(3), J_r(ω) = J_l(ω)ᵀ
+      Random random = new Random(999L);
+      Matrix3D Jl = new Matrix3D();
+      Matrix3D Jr = new Matrix3D();
+
+      for (int i = 0; i < ITERATIONS; i++)
+      {
+         Vector3D omega = EuclidCoreRandomTools.nextRotationVector(random);
+         SO3LieGroupTools.leftJacobian(omega, Jl);
+         SO3LieGroupTools.rightJacobian(omega, Jr);
+
+         assertEquals(Jl.getM00(), Jr.getM00(), EPSILON);
+         assertEquals(Jl.getM01(), Jr.getM10(), EPSILON);
+         assertEquals(Jl.getM02(), Jr.getM20(), EPSILON);
+         assertEquals(Jl.getM10(), Jr.getM01(), EPSILON);
+         assertEquals(Jl.getM11(), Jr.getM11(), EPSILON);
+         assertEquals(Jl.getM12(), Jr.getM21(), EPSILON);
+         assertEquals(Jl.getM20(), Jr.getM02(), EPSILON);
+         assertEquals(Jl.getM21(), Jr.getM12(), EPSILON);
+         assertEquals(Jl.getM22(), Jr.getM22(), EPSILON);
+      }
+   }
+
+   // -----------------------------------------------------------------------
+   // helpers
+   // -----------------------------------------------------------------------
+
+   private static void assertMatrix3DProductIsIdentity(Matrix3D A, Matrix3D B, double epsilon)
+   {
+      for (int r = 0; r < 3; r++)
+      {
+         for (int c = 0; c < 3; c++)
+         {
+            double sum = 0.0;
+            for (int k = 0; k < 3; k++)
+               sum += A.getElement(r, k) * B.getElement(k, c);
+            double expected = (r == c) ? 1.0 : 0.0;
+            assertEquals(expected, sum, epsilon, "A*B element (" + r + "," + c + ")");
+         }
+      }
+   }
+}


### PR DESCRIPTION
I added SO(3) and SE(3) capability so that the new estimator can use this for the state prediction and update steps. This should essentially be a `java` implementation of [`brentyi/jaxlie`](https://github.com/brentyi/jaxlie), just without the autodiff and backprop features that JAX uses. Let me know if this looks good!